### PR TITLE
Implement Header and Hero rendering

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,15 @@
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'quantecportal.com',
+        pathname: '/**',
+      },
+    ],
+  },
 }
 
 module.exports = nextConfig

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,16 @@
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import './globals.css';
+import lpData from '../../lp.json';
 
 const inter = Inter({ subsets: ['latin'] });
 
 export const metadata: Metadata = {
-  title: 'Landing Page Template',
-  description: 'Template moderno para landing pages com Next.js',
+  title: lpData.metadata.title,
+  description: lpData.metadata.description,
+  icons: {
+    icon: lpData.metadata.favicon || '/favicon.ico',
+  },
 };
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,14 +1,27 @@
+import { Header } from '@/components/sections/Header';
+import { Hero } from '@/components/sections/Hero';
+import { LPConfig, HeaderData, HeroData } from '@/types/lp-config';
+import { isSectionEnabled } from '@/lib/utils';
+import lpData from '../../lp.json';
+
+// Type assertion para o JSON importado
+const config = lpData as LPConfig;
+
 export default function Home() {
   return (
-    <main className="min-h-screen">
-      <div className="container-lp py-12">
-        <h1 className="text-4xl font-bold text-center">
-          Next.js LP Template
-        </h1>
-        <p className="text-center mt-4 text-gray-600">
-          Template está pronto para desenvolvimento!
-        </p>
-      </div>
-    </main>
+    <>
+      {config.sections.map((section, index) => {
+        if (!isSectionEnabled(section)) return null;
+
+        switch (section.type) {
+          case 'header':
+            return <Header key={index} data={section.data as HeaderData} />;
+          case 'hero':
+            return <Hero key={index} data={section.data as HeroData} />;
+          default:
+            return null;
+        }
+      })}
+    </>
   );
 }

--- a/src/components/sections/Header.tsx
+++ b/src/components/sections/Header.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import Image from 'next/image';
+import { cn } from '@/lib/utils';
+import { HeaderData, isTextLogo, isImageLogo } from '@/types/lp-config';
+import { sectionDefaults } from '@/config/sections';
+import { typography } from '@/config/typography';
+
+interface HeaderProps {
+  data: HeaderData;
+}
+
+export function Header({ data }: HeaderProps) {
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  
+  const containerStyle = {
+    ...(data.backgroundColor && { backgroundColor: data.backgroundColor }),
+    ...(data.textColor && { color: data.textColor }),
+  } as React.CSSProperties;
+
+  return (
+    <header 
+      className={sectionDefaults.header.classes}
+      style={containerStyle}
+    >
+      <div className={sectionDefaults.header.container}>
+        {/* Logo */}
+        <Link href="/" className="flex items-center">
+          {isTextLogo(data.logo) ? (
+            <div>
+              <div className={cn(typography.logoText.classes)} style={{ color: data.textColor }}>
+                {data.logo.text}
+              </div>
+              {data.logo.subtitle && (
+                <div className={cn(typography.logoSubtitle.classes)} style={{ color: data.textColor }}>
+                  {data.logo.subtitle}
+                </div>
+              )}
+            </div>
+          ) : (
+            <Image
+              src={data.logo.src}
+              alt={data.logo.alt}
+              width={200}
+              height={60}
+              className="h-12 w-auto"
+              priority
+            />
+          )}
+        </Link>
+
+        {/* Desktop Navigation */}
+        <nav className="hidden md:flex items-center gap-8">
+          {data.navigation.map((item, index) => (
+            <a
+              key={index}
+              href={item.href}
+              className={cn(typography.navLink.classes)}
+              style={{ color: data.textColor }}
+            >
+              {item.label}
+            </a>
+          ))}
+          {data.phone && (
+            <a
+              href={data.phone.link}
+              className={cn(typography.navLink.classes, "font-bold")}
+              style={{ color: data.textColor }}
+            >
+              {data.phone.display}
+            </a>
+          )}
+        </nav>
+
+        {/* Mobile Menu Button */}
+        <button
+          onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+          className="md:hidden p-2"
+          style={{ color: data.textColor }}
+          aria-label="Menu"
+        >
+          <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            {mobileMenuOpen ? (
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            ) : (
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+            )}
+          </svg>
+        </button>
+      </div>
+
+      {/* Mobile Menu */}
+      {mobileMenuOpen && (
+        <div className="md:hidden" style={containerStyle}>
+          <nav className="container-lp py-4 space-y-4">
+            {data.navigation.map((item, index) => (
+              <a
+                key={index}
+                href={item.href}
+                className="block py-2"
+                style={{ color: data.textColor }}
+                onClick={() => setMobileMenuOpen(false)}
+              >
+                {item.label}
+              </a>
+            ))}
+            {data.phone && (
+              <a
+                href={data.phone.link}
+                className="block py-2 font-bold"
+                style={{ color: data.textColor }}
+              >
+                {data.phone.display}
+              </a>
+            )}
+          </nav>
+        </div>
+      )}
+    </header>
+  );
+}

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -1,0 +1,61 @@
+import Image from 'next/image';
+import { cn } from '@/lib/utils';
+import { HeroData } from '@/types/lp-config';
+import { Button } from '@/components/ui/Button';
+import { sectionDefaults } from '@/config/sections';
+import { typography } from '@/config/typography';
+
+interface HeroProps {
+  data: HeroData;
+}
+
+export function Hero({ data }: HeroProps) {
+  const sectionStyle = {
+    ...(data.backgroundColor && { backgroundColor: data.backgroundColor }),
+    ...(data.textColor && { color: data.textColor }),
+  } as React.CSSProperties;
+
+  return (
+    <section className={sectionDefaults.hero.classes} style={sectionStyle}>
+      <div className={sectionDefaults.hero.container}>
+        <div className={sectionDefaults.hero.grid}>
+          {/* Text Column */}
+          <div className={sectionDefaults.hero.textColumn}>
+            <h1 
+              className={cn(typography.heroTitle.classes)}
+              style={{ color: data.textColor }}
+            >
+              {data.title}
+            </h1>
+            <p 
+              className={cn(typography.heroDescription.classes)}
+              style={{ color: data.textColor }}
+            >
+              {data.description}
+            </p>
+            <div className="mt-8 flex flex-col sm:flex-row gap-4">
+              <Button {...data.primaryButton} />
+              {data.secondaryButton && (
+                <Button {...data.secondaryButton} />
+              )}
+            </div>
+          </div>
+
+          {/* Image Column */}
+          <div className={sectionDefaults.hero.imageColumn}>
+            <div className="relative aspect-[4/3] lg:aspect-square rounded-2xl overflow-hidden">
+              <Image
+                src={data.image.src}
+                alt={data.image.alt}
+                fill
+                className="object-cover"
+                priority
+                sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 600px"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,52 @@
+import Link from 'next/link';
+import { cn } from '@/lib/utils';
+import { typography } from '@/config/typography';
+
+interface ButtonProps {
+  text: string;
+  href: string;
+  style?: 'primary' | 'secondary' | 'outline' | 'whatsapp';
+  backgroundColor?: string;
+  textColor?: string;
+  className?: string;
+}
+
+export function Button({ 
+  text, 
+  href, 
+  style = 'primary', 
+  backgroundColor,
+  textColor,
+  className 
+}: ButtonProps) {
+  const isExternal = href.startsWith('http') || href.startsWith('tel:');
+  const baseClasses = typography.button.base;
+  const variantClasses = typography.button.variants[style as keyof typeof typography.button.variants] || '';
+  
+  const customStyle = {
+    ...(backgroundColor && { backgroundColor }),
+    ...(textColor && { color: textColor }),
+  } as React.CSSProperties;
+
+  const finalClassName = cn(baseClasses, variantClasses, className);
+
+  if (isExternal) {
+    return (
+      <a
+        href={href}
+        target={href.startsWith('http') ? '_blank' : undefined}
+        rel={href.startsWith('http') ? 'noopener noreferrer' : undefined}
+        className={finalClassName}
+        style={customStyle}
+      >
+        {text}
+      </a>
+    );
+  }
+
+  return (
+    <Link href={href} className={finalClassName} style={customStyle}>
+      {text}
+    </Link>
+  );
+}

--- a/src/types/lp-config.ts
+++ b/src/types/lp-config.ts
@@ -7,7 +7,9 @@ export interface NavItem {
 export interface Button {
   text: string;
   href: string;
-  style?: 'primary' | 'secondary' | 'outline';
+  style?: 'primary' | 'secondary' | 'outline' | 'whatsapp';
+  backgroundColor?: string;
+  textColor?: string;
 }
 
 export interface Image {
@@ -17,22 +19,37 @@ export interface Image {
   height?: number;
 }
 
+// Tipo para logo (pode ser texto ou imagem)
+export type Logo =
+  | {
+      text: string;
+      subtitle?: string;
+    }
+  | {
+      src: string;
+      alt: string;
+    };
+
 // Tipos das seções
 export interface HeaderData {
-  logo: {
-    text: string;
-    subtitle?: string;
-  };
+  logo: Logo;
   navigation: NavItem[];
+  phone?: {
+    display: string;
+    link: string;
+  };
   backgroundColor?: string;
+  textColor?: string;
 }
 
 export interface HeroData {
   title: string;
   description: string;
   primaryButton: Button;
+  secondaryButton?: Button;
   image: Image;
   backgroundColor?: string;
+  textColor?: string;
 }
 
 // União dos tipos de dados das seções
@@ -55,4 +72,13 @@ export interface LPConfig {
     ogImage?: string;
   };
   sections: Section[];
+}
+
+// Type guards para verificar tipo de logo
+export function isTextLogo(logo: Logo): logo is { text: string; subtitle?: string } {
+  return 'text' in logo;
+}
+
+export function isImageLogo(logo: Logo): logo is { src: string; alt: string } {
+  return 'src' in logo && 'alt' in logo;
 }


### PR DESCRIPTION
## Summary
- update lp-config types to match lp.json
- add `Button` UI component
- implement `Header` and `Hero` sections
- load sections dynamically in page
- pull metadata from `lp.json`
- configure remote image patterns for `quantecportal.com`

## Testing
- `npm run format` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: cannot find module 'next')*

------
https://chatgpt.com/codex/tasks/task_e_684f6387147883299effac16659a1f1b