### PR TITLE
Add wildcard https rule for remote images

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -9,6 +9,10 @@ const nextConfig = {
         hostname: 'quantecportal.com',
         pathname: '/**',
       },
+      {
+        protocol: 'https',
+        hostname: '**',
+      },
     ],
   },
 }


### PR DESCRIPTION
## Summary
- allow loading images from any https host by adding a wildcard remote pattern

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_684f7163dc0c832989eb5b4a09ec5378