### PR TITLE
Update global styles to use font variables

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,6 +7,7 @@
     /* Variáveis CSS globais */
     --largura-pagina: clamp(20rem, 100vw, 75rem);
     --fonte-principal: 'Inter', sans-serif;
+    --font-inter: 'Inter', sans-serif;
     --tamanho-base: 1rem;
     --padding-lateral-mobile: 1rem;
     --padding-lateral-md: 1.5rem;
@@ -19,6 +20,7 @@
   body {
     @apply text-gray-900 antialiased;
     font-family: var(--fonte-principal);
+    font-size: var(--tamanho-base);
   }
 }
 
@@ -40,6 +42,9 @@
 
 /* Ajustes responsivos adicionais */
 @layer utilities {
+  .font-inter {
+    font-family: var(--font-inter);
+  }
   /* Previne overflow horizontal em mobile */
   .container-lp {
     @apply overflow-x-hidden;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import { Inter } from 'next/font/google';
 import './globals.css';
 import lpData from '../../lp.json';
 
-const inter = Inter({ subsets: ['latin'] });
+const inter = Inter({ subsets: ['latin'], variable: '--font-inter' });
 
 export const metadata: Metadata = {
   title: lpData.metadata.title,
@@ -20,7 +20,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="pt-BR">
-      <body className={inter.className}>{children}</body>
+      <body className={`${inter.variable} font-inter`}>{children}</body>
     </html>
   );
 }


### PR DESCRIPTION
## Summary
- add `--font-inter` variable
- add `.font-inter` utility class and use consistent base font size
- enable Inter font CSS variable in layout

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f715bd32c8329881e5f875972f2e9