### PR TITLE
Adjust typography to Inter font

### DIFF
--- a/src/config/typography.ts
+++ b/src/config/typography.ts
@@ -2,30 +2,30 @@ export const typography = {
   // Hero
   heroTitle: {
     tag: 'h1' as const,
-    classes: 'text-3xl md:text-4xl lg:text-5xl font-bold leading-tight tracking-tight',
+    classes: 'font-inter text-4xl md:text-5xl lg:text-6xl font-bold leading-tight tracking-tight',
   },
   heroDescription: {
     tag: 'p' as const,
-    classes: 'text-base md:text-lg text-opacity-90 leading-relaxed',
+    classes: 'font-inter text-lg md:text-xl leading-relaxed',
   },
   
   // Header
   logoText: {
     tag: 'div' as const,
-    classes: 'text-xl md:text-2xl font-bold tracking-tight',
+    classes: 'font-inter text-2xl md:text-3xl font-semibold tracking-tight',
   },
   logoSubtitle: {
     tag: 'div' as const,
-    classes: 'text-xs md:text-sm font-normal tracking-wide uppercase opacity-80',
+    classes: 'font-inter text-sm md:text-base font-normal tracking-wide uppercase opacity-80',
   },
   navLink: {
     tag: 'a' as const,
-    classes: 'text-sm md:text-base font-medium',
+    classes: 'font-inter text-base md:text-lg font-medium',
   },
   
   // Botões
   button: {
-    base: 'inline-block text-sm md:text-base font-semibold px-6 py-3 md:px-8 md:py-4 rounded-lg transition-all duration-200 text-center',
+    base: 'inline-block font-inter text-sm md:text-base font-semibold px-6 py-3 md:px-8 md:py-4 rounded-lg transition-all duration-200 text-center',
     variants: {
       primary: 'bg-orange-500 text-white hover:bg-orange-600 shadow-lg hover:shadow-xl',
       secondary: 'bg-gray-200 text-gray-900 hover:bg-gray-300',


### PR DESCRIPTION
## Summary
- tweak global typography sizes
- add `font-inter` to classes

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run format:check` *(fails: cannot find package `prettier-plugin-tailwindcss`)*
- `npm run type-check` *(fails: cannot find module 'next')*

------
https://chatgpt.com/codex/tasks/task_e_684f715e761083299c5794b276e016a6