### PR TITLE
Add benefits and services sections

### DIFF
--- a/lp.json
+++ b/lp.json
@@ -1,55 +1,117 @@
 {
   "metadata": {
-    "title": "Angelo Coviello - Terapeuta Quântico | Medicina Quântica",
+    "title": "Angelo Coviello - Terapeuta Quântico | Medicina Quântica Segura",
     "description": "Terapia Quântica não invasiva, reconhecida na Europa e aplicada com precisão por profissional experiente.",
     "favicon": "/favicon.ico"
   },
   "sections": [
     {
+      "id": "header",
       "type": "header",
-      "enabled": true,
-      "data": {
-        "logo": {
-          "src": "https://quantecportal.com/wp-content/uploads/2025/04/logo-angelo-1-1.svg",
-          "alt": "Angelo Coviello - Terapeuta Quântico"
-        },
-        "navigation": [
-          {
-            "label": "Etapas",
-            "href": "#etapas"
-          },
-          {
-            "label": "Quem Somos",
-            "href": "#quem_somos"
-          }
-        ],
-        "phone": {
-          "display": "(21) 97965-8483",
-          "link": "tel:21979658483"
-        },
-        "backgroundColor": "#7A8AD6",
-        "textColor": "#333333"
+      "backgroundColor": "#7A8AD6",
+      "textColor": "#FFFFFF",
+      "logo": {
+        "type": "text",
+        "text": "ANGELO COVIELLO",
+        "subtitle": "TERAPEUTA QUÂNTICO"
+      },
+      "navigation": [
+        { "label": "Etapas", "href": "#etapas" },
+        { "label": "Quem Somos", "href": "#quem-somos" }
+      ],
+      "phone": {
+        "display": "(21) 97965-8483",
+        "link": "tel:+5521979658483"
       }
     },
     {
+      "id": "hero",
       "type": "hero",
-      "enabled": true,
-      "data": {
-        "title": "Medicina Quântica Segura Com Tecnologia de Ponta",
-        "description": "Terapia Quântica não invasiva, reconhecida na Europa e aplicada com precisão por profissional experiente.",
-        "primaryButton": {
-          "text": "Entenda os Benefícios",
-          "href": "https://wa.me/5521979658483?text=Gostaria%20de%20saber%20mais%20sobre%20a%20terapia",
-          "style": "whatsapp",
-          "backgroundColor": "#FF6600",
-          "textColor": "#333333"
+      "backgroundColor": "#7A8AD6",
+      "textColor": "#15113F",
+      "title": "Medicina Quântica Segura Com Tecnologia de Ponta",
+      "description": "Terapia Quântica não invasiva, reconhecida na Europa e aplicada com precisão por profissional experiente.",
+      "primaryButton": {
+        "text": "Entenda os Benefícios",
+        "href": "#benefits",
+        "variant": "primary"
+      },
+      "image": {
+        "src": "https://quantecportal.com/wp-content/uploads/2025/02/image-7.webp",
+        "alt": "Dr. Angelo Coviello - Terapeuta Quântico"
+      }
+    },
+    {
+      "id": "benefits",
+      "type": "benefits",
+      "backgroundColor": "#F2F2F2",
+      "textColor": "#7A8AD6",
+      "title": "Os Benefícios da Energia Quântica no seu dia a dia",
+      "items": [
+        {
+          "icon": "🧘‍♀️",
+          "title": "Alívio Progressivo do Estresse",
+          "description": "Sinta a diferença no seu ritmo interno. O tratamento busca favorecer um estado de maior equilíbrio e tranquilidade ao longo do tempo."
         },
-        "image": {
-          "src": "https://quantecportal.com/wp-content/uploads/2025/03/foto-angelo.webp",
-          "alt": "Angelo Coviello - Terapeuta Quântico"
+        {
+          "icon": "⚡",
+          "title": "Energia Renovada para Seu Dia a Dia",
+          "description": "Muitos relatam melhora gradual na disposição. A terapia energética pode colaborar com o equilíbrio no cotidiano."
         },
-        "backgroundColor": "#7A8AD6",
-        "textColor": "#333333"
+        {
+          "icon": "🛡️",
+          "title": "Fortalecimento do Sistema Imunológico",
+          "description": "O equilíbrio energético pode melhorar o funcionamento do organismo. Muitas pessoas relatam bem-estar durante o processo."
+        },
+        {
+          "icon": "🌙",
+          "title": "Melhora na Qualidade do Sono",
+          "description": "Alguns clientes percebem mudanças positivas no sono, como sensação de descanso mais profundo e regular."
+        },
+        {
+          "icon": "🧠",
+          "title": "Aumento da Clareza Mental",
+          "description": "O reequilíbrio energético pode favorecer estados de maior concentração, contribuindo para decisões mais conscientes no dia a dia."
+        },
+        {
+          "icon": "💖",
+          "title": "Harmonia Emocional Duradoura",
+          "description": "O tratamento atua de forma sutil no campo emocional, podendo favorecer estabilidade interna e maior percepção de equilíbrio ao longo do tempo."
+        }
+      ]
+    },
+    {
+      "id": "services",
+      "type": "services",
+      "backgroundColor": "#F3F3F3",
+      "textColor": "#15113F",
+      "title": "Terapia Quântica: Como Funciona",
+      "items": [
+        {
+          "icon": "🧠",
+          "text": "A terapia busca identificar padrões sutis — emocionais, mentais, físicos ou energéticos — que influenciam a vida da pessoa, mesmo sem que ela perceba de forma consciente."
+        },
+        {
+          "icon": "⚖️",
+          "text": "Esses desequilíbrios podem estar por trás de conflitos, bloqueios ou desconfortos. Lidar com essas causas ajuda a promover mudanças reais no cotidiano."
+        },
+        {
+          "icon": "🔄",
+          "text": "Cada pessoa reage de forma única, por isso os resultados podem variar de acordo com a experiência e o momento de cada um."
+        },
+        {
+          "icon": "🌱",
+          "text": "A terapia não é uma promessa, mas tende a funcionar melhor quando há abertura para se observar, escutar a si mesmo e aplicar pequenas mudanças conscientes no seu dia a dia."
+        }
+      ],
+      "image": {
+        "src": "https://quantecportal.com/wp-content/uploads/2025/03/image-18-300x300.webp",
+        "alt": "Terapia Quântica - Como Funciona"
+      },
+      "button": {
+        "text": "Entenda os Benefícios",
+        "href": "https://wa.me/5521979658483?text=Gostaria%20de%20saber%20mais%20sobre%20a%20terapia",
+        "variant": "primary"
       }
     }
   ]

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,27 +1,9 @@
-import { Header } from '@/components/sections/Header';
-import { Hero } from '@/components/sections/Hero';
-import { LPConfig, HeaderData, HeroData } from '@/types/lp-config';
-import { isSectionEnabled } from '@/lib/utils';
+import { LandingPage } from '@/components/LandingPage';
+import { LandingPageData } from '@/types/lp-config';
 import lpData from '../../lp.json';
 
-// Type assertion para o JSON importado
-const config = lpData as LPConfig;
+const config = lpData as LandingPageData;
 
 export default function Home() {
-  return (
-    <>
-      {config.sections.map((section, index) => {
-        if (!isSectionEnabled(section)) return null;
-
-        switch (section.type) {
-          case 'header':
-            return <Header key={index} data={section.data as HeaderData} />;
-          case 'hero':
-            return <Hero key={index} data={section.data as HeroData} />;
-          default:
-            return null;
-        }
-      })}
-    </>
-  );
+  return <LandingPage data={config} />;
 }

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { LandingPageData } from '@/types/lp-config';
+import { Header } from './sections/Header';
+import { Hero } from './sections/Hero';
+import { Benefits } from './sections/Benefits';
+import { Services } from './sections/Services';
+
+interface LandingPageProps {
+  data: LandingPageData;
+}
+
+const sectionComponents = {
+  header: Header,
+  hero: Hero,
+  benefits: Benefits,
+  services: Services,
+};
+
+export function LandingPage({ data }: LandingPageProps) {
+  return (
+    <>
+      {data.sections.map((section) => {
+        const Component = sectionComponents[section.type];
+        if (!Component) return null;
+
+        return <Component key={section.id} data={section as any} />;
+      })}
+    </>
+  );
+}

--- a/src/components/sections/Benefits.tsx
+++ b/src/components/sections/Benefits.tsx
@@ -1,0 +1,57 @@
+import { cn } from '@/lib/utils';
+import { BenefitsData } from '@/types/lp-config';
+import { sectionDefaults } from '@/config/sections';
+import { typography } from '@/config/typography';
+
+interface BenefitsProps {
+  data: BenefitsData;
+}
+
+export function Benefits({ data }: BenefitsProps) {
+  const sectionStyle = {
+    ...(data.backgroundColor && { backgroundColor: data.backgroundColor }),
+    ...(data.textColor && { color: data.textColor }),
+  } as React.CSSProperties;
+
+  return (
+    <section className={sectionDefaults.benefits.classes} style={sectionStyle}>
+      <div className={sectionDefaults.benefits.container}>
+        {/* Título centralizado */}
+        <div className={sectionDefaults.benefits.titleContainer}>
+          <h2
+            className={cn(typography.sectionTitle.classes)}
+            style={{ color: data.textColor }}
+          >
+            {data.title}
+          </h2>
+        </div>
+
+        {/* Grid de benefícios */}
+        <div className={sectionDefaults.benefits.grid}>
+          {data.items.map((item, index) => (
+            <div key={index} className={sectionDefaults.benefits.cardContainer}>
+              {/* Ícone */}
+              <div className={sectionDefaults.benefits.iconContainer}>{item.icon}</div>
+
+              {/* Título H3 */}
+              <h3
+                className={cn(typography.sectionSubtitle.classes)}
+                style={{ color: data.textColor }}
+              >
+                {item.title}
+              </h3>
+
+              {/* Descrição */}
+              <p
+                className={cn(typography.bodyText.classes)}
+                style={{ color: data.textColor }}
+              >
+                {item.description}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/Services.tsx
+++ b/src/components/sections/Services.tsx
@@ -1,0 +1,74 @@
+import Image from 'next/image';
+import { cn } from '@/lib/utils';
+import { ServicesData } from '@/types/lp-config';
+import { Button } from '@/components/ui/Button';
+import { sectionDefaults } from '@/config/sections';
+import { typography } from '@/config/typography';
+
+interface ServicesProps {
+  data: ServicesData;
+}
+
+export function Services({ data }: ServicesProps) {
+  const sectionStyle = {
+    ...(data.backgroundColor && { backgroundColor: data.backgroundColor }),
+    ...(data.textColor && { color: data.textColor }),
+  } as React.CSSProperties;
+
+  return (
+    <section className={sectionDefaults.services.classes} style={sectionStyle}>
+      <div className={sectionDefaults.services.container}>
+        {/* Título centralizado */}
+        <div className={sectionDefaults.services.titleContainer}>
+          <h2
+            className={cn(typography.sectionTitle.classes)}
+            style={{ color: data.textColor }}
+          >
+            {data.title}
+          </h2>
+        </div>
+
+        {/* Conteúdo: imagem à esquerda, textos à direita */}
+        <div className={sectionDefaults.services.contentLayout}>
+          {/* Container da imagem */}
+          <div className={sectionDefaults.services.imageContainer}>
+            <div className="relative w-full max-w-md mx-auto aspect-square rounded-2xl overflow-hidden shadow-xl">
+              <Image
+                src={data.image.src}
+                alt={data.image.alt}
+                fill
+                className="object-cover"
+                sizes="(max-width: 768px) 100vw, 400px"
+              />
+            </div>
+          </div>
+
+          {/* Container dos textos */}
+          <div className={sectionDefaults.services.textContainer}>
+            {data.items.map((item, index) => (
+              <div key={index} className={sectionDefaults.services.textItem}>
+                {/* Ícone inline */}
+                <span className={sectionDefaults.services.iconInline}>{item.icon}</span>
+
+                {/* Texto */}
+                <p
+                  className={cn(typography.bodyText.classes, 'mb-0')}
+                  style={{ color: data.textColor }}
+                >
+                  {item.text}
+                </p>
+              </div>
+            ))}
+
+            {/* Botão */}
+            {data.button && (
+              <div className={sectionDefaults.services.buttonContainer}>
+                <Button {...data.button} />
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,52 +1,22 @@
-import Link from 'next/link';
 import { cn } from '@/lib/utils';
+import { ButtonData } from '@/types/lp-config';
 import { typography } from '@/config/typography';
 
-interface ButtonProps {
-  text: string;
-  href: string;
-  style?: 'primary' | 'secondary' | 'outline' | 'whatsapp';
-  backgroundColor?: string;
-  textColor?: string;
-  className?: string;
-}
-
-export function Button({ 
-  text, 
-  href, 
-  style = 'primary', 
-  backgroundColor,
-  textColor,
-  className 
-}: ButtonProps) {
-  const isExternal = href.startsWith('http') || href.startsWith('tel:');
-  const baseClasses = typography.button.base;
-  const variantClasses = typography.button.variants[style as keyof typeof typography.button.variants] || '';
-  
-  const customStyle = {
-    ...(backgroundColor && { backgroundColor }),
-    ...(textColor && { color: textColor }),
-  } as React.CSSProperties;
-
-  const finalClassName = cn(baseClasses, variantClasses, className);
-
-  if (isExternal) {
-    return (
-      <a
-        href={href}
-        target={href.startsWith('http') ? '_blank' : undefined}
-        rel={href.startsWith('http') ? 'noopener noreferrer' : undefined}
-        className={finalClassName}
-        style={customStyle}
-      >
-        {text}
-      </a>
-    );
-  }
+export function Button({ text, href, variant = 'primary' }: ButtonData) {
+  const customStyles =
+    variant === 'primary' && href.includes('wa.me')
+      ? { backgroundColor: '#FF6600', color: '#333333' }
+      : {};
 
   return (
-    <Link href={href} className={finalClassName} style={customStyle}>
+    <a
+      href={href}
+      className={cn(typography.button.base, typography.button.variants[variant])}
+      style={customStyles}
+      target={href.startsWith('http') ? '_blank' : undefined}
+      rel={href.startsWith('http') ? 'noopener noreferrer' : undefined}
+    >
       {text}
-    </Link>
+    </a>
   );
 }

--- a/src/config/sections.ts
+++ b/src/config/sections.ts
@@ -17,4 +17,27 @@ export const sectionDefaults = {
     textContainer: 'flex-1 flex flex-col space-y-6 text-center md:text-left',
     imageContainer: 'flex-1 w-full md:w-auto',
   },
+
+  benefits: {
+    structure: 'Título centralizado, grid de benefícios com ícone + título + texto',
+    classes: 'py-12 md:py-16 mb-12',
+    container: 'container-lp',
+    titleContainer: 'text-center mb-12',
+    grid: 'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 md:gap-10',
+    cardContainer: 'flex flex-col items-center text-center space-y-4',
+    iconContainer: 'text-4xl mb-2',
+  },
+
+  services: {
+    structure: 'Título centralizado, imagem à esquerda e textos à direita',
+    classes: 'py-12 md:py-16 mb-12',
+    container: 'container-lp',
+    titleContainer: 'text-center mb-12',
+    contentLayout: 'flex flex-col md:flex-row gap-12 md:gap-16 items-center',
+    imageContainer: 'flex-1 w-full md:w-auto',
+    textContainer: 'flex-1 space-y-6',
+    textItem: 'flex gap-4',
+    iconInline: 'text-2xl flex-shrink-0 mt-1',
+    buttonContainer: 'mt-8 text-center md:text-left',
+  },
 };

--- a/src/types/lp-config.ts
+++ b/src/types/lp-config.ts
@@ -1,84 +1,97 @@
-// Tipos base compartilhados
-export interface NavItem {
-  label: string;
-  href: string;
+export interface LandingPageData {
+  metadata: MetaData;
+  sections: SectionData[];
 }
 
-export interface Button {
-  text: string;
-  href: string;
-  style?: 'primary' | 'secondary' | 'outline' | 'whatsapp';
+export interface MetaData {
+  title: string;
+  description: string;
+  favicon?: string;
+}
+
+export type SectionData = HeaderData | HeroData | BenefitsData | ServicesData;
+
+export interface BaseSection {
+  id: string;
+  type: 'header' | 'hero' | 'benefits' | 'services';
   backgroundColor?: string;
   textColor?: string;
 }
 
-export interface Image {
-  src: string;
-  alt: string;
-  width?: number;
-  height?: number;
-}
-
-// Tipo para logo (pode ser texto ou imagem)
-export type Logo =
-  | {
-      text: string;
-      subtitle?: string;
-    }
-  | {
-      src: string;
-      alt: string;
-    };
-
-// Tipos das seções
-export interface HeaderData {
+export interface HeaderData extends BaseSection {
+  type: 'header';
   logo: Logo;
-  navigation: NavItem[];
+  navigation: NavigationItem[];
   phone?: {
     display: string;
     link: string;
   };
-  backgroundColor?: string;
-  textColor?: string;
 }
 
-export interface HeroData {
+export interface HeroData extends BaseSection {
+  type: 'hero';
   title: string;
   description: string;
-  primaryButton: Button;
-  secondaryButton?: Button;
-  image: Image;
-  backgroundColor?: string;
-  textColor?: string;
+  primaryButton: ButtonData;
+  secondaryButton?: ButtonData;
+  image: ImageData;
 }
 
-// União dos tipos de dados das seções
-export type SectionData = HeaderData | HeroData;
-
-// Tipo da seção
-export interface Section {
-  type: 'header' | 'hero';
-  enabled?: boolean;
-  data: SectionData;
+export interface BenefitsData extends BaseSection {
+  type: 'benefits';
+  title: string;
+  items: BenefitItem[];
 }
 
-// Tipo principal do arquivo lp.json
-export interface LPConfig {
-  metadata: {
-    title: string;
-    description: string;
-    keywords?: string;
-    favicon?: string;
-    ogImage?: string;
-  };
-  sections: Section[];
+export interface BenefitItem {
+  icon: string;
+  title: string;
+  description: string;
 }
 
-// Type guards para verificar tipo de logo
-export function isTextLogo(logo: Logo): logo is { text: string; subtitle?: string } {
-  return 'text' in logo;
+export interface ServicesData extends BaseSection {
+  type: 'services';
+  title: string;
+  items: ServiceItem[];
+  image: ImageData;
+  button?: ButtonData;
 }
 
-export function isImageLogo(logo: Logo): logo is { src: string; alt: string } {
-  return 'src' in logo && 'alt' in logo;
+export interface ServiceItem {
+  icon: string;
+  text: string;
 }
+
+export interface ButtonData {
+  text: string;
+  href: string;
+  variant?: 'primary' | 'secondary' | 'outline' | 'whatsapp';
+}
+
+export interface ImageData {
+  src: string;
+  alt: string;
+}
+
+export type Logo = TextLogo | ImageLogo;
+
+export interface TextLogo {
+  type: 'text';
+  text: string;
+  subtitle?: string;
+}
+
+export interface ImageLogo {
+  type: 'image';
+  src: string;
+  alt: string;
+}
+
+export interface NavigationItem {
+  label: string;
+  href: string;
+}
+
+export const isTextLogo = (logo: Logo): logo is TextLogo => {
+  return logo.type === 'text';
+};


### PR DESCRIPTION
## Summary
- extend section defaults with benefits and services layouts
- update landing page types to support new sections
- implement Benefits and Services section components
- add LandingPage component and use it in the home page
- simplify Button component API
- update sample `lp.json` with benefits and services data

## Testing
- `npm run type-check` *(fails: Cannot find module 'next' or its corresponding type declarations)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685029fe3e2883299c7773bd3ee3fa7f