### PR TITLE
Fix typed landing page rendering

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import { LandingPageData } from '@/types/lp-config';
+import {
+  LandingPageData,
+  SectionData,
+  HeaderData,
+  HeroData,
+  BenefitsData,
+  ServicesData,
+} from '@/types/lp-config';
 import { Header } from './sections/Header';
 import { Hero } from './sections/Hero';
 import { Benefits } from './sections/Benefits';
@@ -10,7 +17,13 @@ interface LandingPageProps {
   data: LandingPageData;
 }
 
-const sectionComponents = {
+type SectionComponent =
+  | typeof Header
+  | typeof Hero
+  | typeof Benefits
+  | typeof Services;
+
+const sectionComponents: Record<SectionData['type'], SectionComponent> = {
   header: Header,
   hero: Hero,
   benefits: Benefits,
@@ -24,7 +37,18 @@ export function LandingPage({ data }: LandingPageProps) {
         const Component = sectionComponents[section.type];
         if (!Component) return null;
 
-        return <Component key={section.id} data={section as any} />;
+        switch (section.type) {
+          case 'header':
+            return <Header key={section.id} data={section as HeaderData} />;
+          case 'hero':
+            return <Hero key={section.id} data={section as HeroData} />;
+          case 'benefits':
+            return <Benefits key={section.id} data={section as BenefitsData} />;
+          case 'services':
+            return <Services key={section.id} data={section as ServicesData} />;
+          default:
+            return null;
+        }
       })}
     </>
   );


### PR DESCRIPTION
## Summary
- strongly type LandingPage section props
- render sections via discriminated union

## Testing
- `npm run type-check` *(fails: Cannot find module)*
- `npm run format:check`
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68502c3c61c883298fa00ccf04ddf015