### PR TITLE
Fix layout defaults

### DIFF
--- a/src/config/sections.ts
+++ b/src/config/sections.ts
@@ -1,7 +1,7 @@
 export const sectionDefaults = {
   header: {
     structure: 'Logo à esquerda, menu/telefone à direita',
-    classes: 'w-full py-4 mb-8',
+    classes: 'w-full py-4 mb-0',
     container: 'container-lp',
     grid: 'flex items-center justify-between',
     logoContainer: 'flex-shrink-0',
@@ -11,7 +11,7 @@ export const sectionDefaults = {
 
   hero: {
     structure: 'Dois containers: texto (vertical) e imagem. Mobile empilha, desktop lado a lado.',
-    classes: 'py-12 md:py-16 mb-12',
+    classes: 'py-12 md:py-16',
     container: 'container-lp',
     layout: 'flex flex-col md:flex-row gap-12 md:gap-16 items-center',
     textContainer: 'flex-1 flex flex-col space-y-6 text-center md:text-left',
@@ -19,25 +19,26 @@ export const sectionDefaults = {
   },
 
   benefits: {
-    structure: 'Título centralizado, grid de benefícios com ícone + título + texto',
-    classes: 'py-12 md:py-16 mb-12',
+    structure: 'Título centralizado, 2 containers lado a lado com 3 benefícios cada',
+    classes: 'py-12 md:py-16',
     container: 'container-lp',
     titleContainer: 'text-center mb-12',
-    grid: 'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 md:gap-10',
+    layout: 'grid grid-cols-1 md:grid-cols-2 gap-12 md:gap-16',
+    column: 'space-y-8',
     cardContainer: 'flex flex-col items-center text-center space-y-4',
     iconContainer: 'text-4xl mb-2',
   },
 
   services: {
-    structure: 'Título centralizado, imagem à esquerda e textos à direita',
-    classes: 'py-12 md:py-16 mb-12',
+    structure: 'Título centralizado, imagem à esquerda e textos à direita, botão centralizado abaixo',
+    classes: 'py-12 md:py-16',
     container: 'container-lp',
     titleContainer: 'text-center mb-12',
-    contentLayout: 'flex flex-col md:flex-row gap-12 md:gap-16 items-center',
+    contentLayout: 'flex flex-col md:flex-row gap-12 md:gap-16 items-center mb-12',
     imageContainer: 'flex-1 w-full md:w-auto',
     textContainer: 'flex-1 space-y-6',
     textItem: 'flex gap-4',
     iconInline: 'text-2xl flex-shrink-0 mt-1',
-    buttonContainer: 'mt-8 text-center md:text-left',
+    buttonContainer: 'text-center',
   },
 };


### PR DESCRIPTION
## Summary
- update section layout defaults to remove extra margins

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: cannot find module 'next')*

------
https://chatgpt.com/codex/tasks/task_e_68502f567f24832993de9a38f929d38b