### PR TITLE
Add new landing page sections

### DIFF
--- a/lp.json
+++ b/lp.json
@@ -113,6 +113,81 @@
         "href": "https://wa.me/5521979658483?text=Gostaria%20de%20saber%20mais%20sobre%20a%20terapia",
         "variant": "primary"
       }
+    },
+    {
+      "id": "testimonials",
+      "type": "testimonials",
+      "backgroundColor": "#FFFFFF",
+      "textColor": "#15113F",
+      "title": "Depoimentos",
+      "videos": [
+        { "embedUrl": "https://www.youtube.com/embed/dQw4w9WgXcQ" },
+        { "embedUrl": "https://www.youtube.com/embed/dQw4w9WgXcQ" },
+        { "embedUrl": "https://www.youtube.com/embed/dQw4w9WgXcQ" }
+      ]
+    },
+    {
+      "id": "steps",
+      "type": "steps",
+      "backgroundColor": "#F8F8F8",
+      "textColor": "#15113F",
+      "title": "Etapas",
+      "steps": [
+        { "title": "Passo 1", "description": "Descrição do passo 1" },
+        { "title": "Passo 2", "description": "Descrição do passo 2" }
+      ],
+      "button": { "text": "Saiba Mais", "href": "#", "variant": "primary" }
+    },
+    {
+      "id": "technology",
+      "type": "technology",
+      "backgroundColor": "#FFFFFF",
+      "textColor": "#15113F",
+      "title": "Tecnologia",
+      "items": [
+        { "icon": "⚙️", "title": "Tecnologia 1", "description": "Descrição" },
+        { "icon": "🧪", "title": "Tecnologia 2", "description": "Descrição" }
+      ],
+      "image": { "src": "https://via.placeholder.com/400", "alt": "Tech" },
+      "button": { "text": "Ver Mais", "href": "#", "variant": "primary" }
+    },
+    {
+      "id": "about",
+      "type": "about",
+      "backgroundColor": "#F2F2F2",
+      "textColor": "#15113F",
+      "title": "Quem Somos",
+      "description": "Breve descrição sobre a empresa.",
+      "image": { "src": "https://via.placeholder.com/400", "alt": "Quem Somos" }
+    },
+    {
+      "id": "faq",
+      "type": "faq",
+      "backgroundColor": "#FFFFFF",
+      "textColor": "#15113F",
+      "title": "Perguntas Frequentes",
+      "items": [
+        { "question": "Pergunta 1?", "answer": "Resposta 1." },
+        { "question": "Pergunta 2?", "answer": "Resposta 2." }
+      ]
+    },
+    {
+      "id": "ctaFinal",
+      "type": "ctaFinal",
+      "backgroundColor": "#7A8AD6",
+      "textColor": "#FFFFFF",
+      "title": "Entre em Contato",
+      "subtitle": "Agende sua consulta hoje mesmo",
+      "button": { "text": "WhatsApp", "href": "https://wa.me/5521979658483", "variant": "whatsapp" }
+    },
+    {
+      "id": "footer",
+      "type": "footer",
+      "backgroundColor": "#F3F3F3",
+      "textColor": "#15113F",
+      "instagram": { "url": "https://instagram.com", "text": "@perfil" },
+      "copyright": "© 2025 Empresa",
+      "legalLink": { "text": "Termos de Uso", "href": "#" }
     }
   ]
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -45,6 +45,30 @@
     @apply overflow-x-hidden;
   }
 
+  /* Remover scrollbar do carrossel */
+  .scrollbar-hide {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+
+  .scrollbar-hide::-webkit-scrollbar {
+    display: none;
+  }
+
+  /* Estilos para o iframe responsivo */
+  .aspect-video {
+    position: relative;
+    padding-top: 56.25%;
+  }
+
+  .aspect-video iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+
   /* Classes customizadas para tipografia */
   .font-inter {
     font-family: var(--fonte-principal);

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -7,11 +7,25 @@ import {
   HeroData,
   BenefitsData,
   ServicesData,
+  TestimonialsData,
+  StepsData,
+  TechnologyData,
+  AboutData,
+  FAQData,
+  CTAFinalData,
+  FooterData,
 } from '@/types/lp-config';
 import { Header } from './sections/Header';
 import { Hero } from './sections/Hero';
 import { Benefits } from './sections/Benefits';
 import { Services } from './sections/Services';
+import { Testimonials } from './sections/Testimonials';
+import { Steps } from './sections/Steps';
+import { Technology } from './sections/Technology';
+import { About } from './sections/About';
+import { FAQ } from './sections/FAQ';
+import { CTAFinal } from './sections/CTAFinal';
+import { Footer } from './sections/Footer';
 
 interface LandingPageProps {
   data: LandingPageData;
@@ -21,13 +35,27 @@ type SectionComponent =
   | typeof Header
   | typeof Hero
   | typeof Benefits
-  | typeof Services;
+  | typeof Services
+  | typeof Testimonials
+  | typeof Steps
+  | typeof Technology
+  | typeof About
+  | typeof FAQ
+  | typeof CTAFinal
+  | typeof Footer;
 
 const sectionComponents: Record<SectionData['type'], SectionComponent> = {
   header: Header,
   hero: Hero,
   benefits: Benefits,
   services: Services,
+  testimonials: Testimonials,
+  steps: Steps,
+  technology: Technology,
+  about: About,
+  faq: FAQ,
+  ctaFinal: CTAFinal,
+  footer: Footer,
 };
 
 export function LandingPage({ data }: LandingPageProps) {
@@ -46,6 +74,20 @@ export function LandingPage({ data }: LandingPageProps) {
             return <Benefits key={section.id} data={section as BenefitsData} />;
           case 'services':
             return <Services key={section.id} data={section as ServicesData} />;
+          case 'testimonials':
+            return <Testimonials key={section.id} data={section as TestimonialsData} />;
+          case 'steps':
+            return <Steps key={section.id} data={section as StepsData} />;
+          case 'technology':
+            return <Technology key={section.id} data={section as TechnologyData} />;
+          case 'about':
+            return <About key={section.id} data={section as AboutData} />;
+          case 'faq':
+            return <FAQ key={section.id} data={section as FAQData} />;
+          case 'ctaFinal':
+            return <CTAFinal key={section.id} data={section as CTAFinalData} />;
+          case 'footer':
+            return <Footer key={section.id} data={section as FooterData} />;
           default:
             return null;
         }

--- a/src/components/sections/About.tsx
+++ b/src/components/sections/About.tsx
@@ -1,0 +1,51 @@
+import Image from 'next/image';
+import { cn } from '@/lib/utils';
+import { AboutData } from '@/types/lp-config';
+import { sectionDefaults } from '@/config/sections';
+import { typography } from '@/config/typography';
+
+interface AboutProps {
+  data: AboutData;
+}
+
+export function About({ data }: AboutProps) {
+  const sectionStyle = {
+    ...(data.backgroundColor && { backgroundColor: data.backgroundColor }),
+    ...(data.textColor && { color: data.textColor }),
+  } as React.CSSProperties;
+
+  return (
+    <section className={sectionDefaults.about.classes} style={sectionStyle}>
+      <div className={sectionDefaults.about.container}>
+        <div className={sectionDefaults.about.layout}>
+          <div className={sectionDefaults.about.imageContainer}>
+            <div className="relative w-full max-w-md mx-auto aspect-square rounded-2xl overflow-hidden shadow-xl">
+              <Image
+                src={data.image.src}
+                alt={data.image.alt}
+                fill
+                className="object-cover"
+                sizes="(max-width: 768px) 100vw, 400px"
+              />
+            </div>
+          </div>
+
+          <div className={sectionDefaults.about.textContainer}>
+            <h2
+              className={cn(typography.sectionTitle.classes)}
+              style={{ color: data.textColor }}
+            >
+              {data.title}
+            </h2>
+            <p
+              className={cn(typography.bodyText.classes)}
+              style={{ color: data.textColor }}
+            >
+              {data.description}
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/Benefits.tsx
+++ b/src/components/sections/Benefits.tsx
@@ -27,27 +27,26 @@ export function Benefits({ data }: BenefitsProps) {
         </div>
 
         {/* Grid de benefícios */}
-        <div className={sectionDefaults.benefits.grid}>
-          {data.items.map((item, index) => (
-            <div key={index} className={sectionDefaults.benefits.cardContainer}>
-              {/* Ícone */}
-              <div className={sectionDefaults.benefits.iconContainer}>{item.icon}</div>
-
-              {/* Título H3 */}
-              <h3
-                className={cn(typography.sectionSubtitle.classes)}
-                style={{ color: data.textColor }}
-              >
-                {item.title}
-              </h3>
-
-              {/* Descrição */}
-              <p
-                className={cn(typography.bodyText.classes)}
-                style={{ color: data.textColor }}
-              >
-                {item.description}
-              </p>
+        <div className={sectionDefaults.benefits.layout}>
+          {[0, 1].map((col) => (
+            <div key={col} className={sectionDefaults.benefits.column}>
+              {data.items.slice(col * 3, col * 3 + 3).map((item, index) => (
+                <div key={index} className={sectionDefaults.benefits.cardContainer}>
+                  <div className={sectionDefaults.benefits.iconContainer}>{item.icon}</div>
+                  <h3
+                    className={cn(typography.sectionSubtitle.classes)}
+                    style={{ color: data.textColor }}
+                  >
+                    {item.title}
+                  </h3>
+                  <p
+                    className={cn(typography.bodyText.classes)}
+                    style={{ color: data.textColor }}
+                  >
+                    {item.description}
+                  </p>
+                </div>
+              ))}
             </div>
           ))}
         </div>

--- a/src/components/sections/CTAFinal.tsx
+++ b/src/components/sections/CTAFinal.tsx
@@ -1,0 +1,38 @@
+import { cn } from '@/lib/utils';
+import { CTAFinalData } from '@/types/lp-config';
+import { Button } from '@/components/ui/Button';
+import { sectionDefaults } from '@/config/sections';
+import { typography } from '@/config/typography';
+
+interface CTAFinalProps {
+  data: CTAFinalData;
+}
+
+export function CTAFinal({ data }: CTAFinalProps) {
+  const sectionStyle = {
+    ...(data.backgroundColor && { backgroundColor: data.backgroundColor }),
+    ...(data.textColor && { color: data.textColor }),
+  } as React.CSSProperties;
+
+  return (
+    <section className={sectionDefaults.ctaFinal.classes} style={sectionStyle}>
+      <div className={sectionDefaults.ctaFinal.container}>
+        <div className={sectionDefaults.ctaFinal.contentContainer}>
+          <h2
+            className={cn(typography.heroTitle.classes)}
+            style={{ color: data.textColor }}
+          >
+            {data.title}
+          </h2>
+          <h3
+            className={cn(typography.heroDescription.classes)}
+            style={{ color: data.textColor }}
+          >
+            {data.subtitle}
+          </h3>
+          <Button {...data.button} />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/FAQ.tsx
+++ b/src/components/sections/FAQ.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useState } from 'react';
+import { cn } from '@/lib/utils';
+import { FAQData } from '@/types/lp-config';
+import { sectionDefaults } from '@/config/sections';
+import { typography } from '@/config/typography';
+import { ChevronDown } from 'lucide-react';
+
+interface FAQProps {
+  data: FAQData;
+}
+
+export function FAQ({ data }: FAQProps) {
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+
+  const sectionStyle = {
+    ...(data.backgroundColor && { backgroundColor: data.backgroundColor }),
+    ...(data.textColor && { color: data.textColor }),
+  } as React.CSSProperties;
+
+  const toggleAccordion = (index: number) => {
+    setOpenIndex(openIndex === index ? null : index);
+  };
+
+  return (
+    <section className={sectionDefaults.faq.classes} style={sectionStyle}>
+      <div className={sectionDefaults.faq.container}>
+        <div className={sectionDefaults.faq.titleContainer}>
+          <h2
+            className={cn(typography.sectionTitle.classes)}
+            style={{ color: data.textColor }}
+          >
+            {data.title}
+          </h2>
+        </div>
+
+        <div className={sectionDefaults.faq.accordionContainer}>
+          {data.items.map((item, index) => (
+            <div key={index} className={sectionDefaults.faq.accordionItem}>
+              <button
+                onClick={() => toggleAccordion(index)}
+                className={sectionDefaults.faq.accordionTrigger}
+                style={{ color: data.textColor }}
+              >
+                <span className={cn(typography.sectionSubtitle.classes, 'mb-0')}>
+                  {item.question}
+                </span>
+                <ChevronDown
+                  className={cn(
+                    'w-5 h-5 transition-transform',
+                    openIndex === index && 'rotate-180'
+                  )}
+                />
+              </button>
+              {openIndex === index && (
+                <div className={sectionDefaults.faq.accordionContent}>
+                  <p
+                    className={cn(typography.bodyText.classes, 'mb-0')}
+                    style={{ color: data.textColor }}
+                  >
+                    {item.answer}
+                  </p>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/Footer.tsx
+++ b/src/components/sections/Footer.tsx
@@ -1,0 +1,53 @@
+import { cn } from '@/lib/utils';
+import { FooterData } from '@/types/lp-config';
+import { sectionDefaults } from '@/config/sections';
+import { typography } from '@/config/typography';
+import { Instagram } from 'lucide-react';
+
+interface FooterProps {
+  data: FooterData;
+}
+
+export function Footer({ data }: FooterProps) {
+  const sectionStyle = {
+    ...(data.backgroundColor && { backgroundColor: data.backgroundColor }),
+    ...(data.textColor && { color: data.textColor }),
+  } as React.CSSProperties;
+
+  return (
+    <footer className={sectionDefaults.footer.classes} style={sectionStyle}>
+      <div className={sectionDefaults.footer.container}>
+        <div className={sectionDefaults.footer.layout}>
+          <div className={sectionDefaults.footer.leftContainer}>
+            <a
+              href={data.instagram.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-2 hover:opacity-80 transition-opacity"
+              style={{ color: data.textColor }}
+            >
+              <Instagram className="w-5 h-5" />
+              <span>{data.instagram.text}</span>
+            </a>
+            <small
+              className={cn(typography.footnote.classes)}
+              style={{ color: data.textColor }}
+            >
+              {data.copyright}
+            </small>
+          </div>
+
+          <div className={sectionDefaults.footer.rightContainer}>
+            <a
+              href={data.legalLink.href}
+              className={cn(typography.footnote.classes, 'hover:underline')}
+              style={{ color: data.textColor }}
+            >
+              {data.legalLink.text}
+            </a>
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/sections/Steps.tsx
+++ b/src/components/sections/Steps.tsx
@@ -1,0 +1,54 @@
+import { cn } from '@/lib/utils';
+import { StepsData } from '@/types/lp-config';
+import { Button } from '@/components/ui/Button';
+import { sectionDefaults } from '@/config/sections';
+import { typography } from '@/config/typography';
+
+interface StepsProps {
+  data: StepsData;
+}
+
+export function Steps({ data }: StepsProps) {
+  const sectionStyle = {
+    ...(data.backgroundColor && { backgroundColor: data.backgroundColor }),
+    ...(data.textColor && { color: data.textColor }),
+  } as React.CSSProperties;
+
+  return (
+    <section className={sectionDefaults.steps.classes} style={sectionStyle}>
+      <div className={sectionDefaults.steps.container}>
+        <div className={sectionDefaults.steps.titleContainer}>
+          <h2
+            className={cn(typography.sectionTitle.classes)}
+            style={{ color: data.textColor }}
+          >
+            {data.title}
+          </h2>
+        </div>
+
+        <div className={sectionDefaults.steps.layout}>
+          {data.steps.map((step, index) => (
+            <div key={index} className={sectionDefaults.steps.stepContainer}>
+              <h3
+                className={cn(typography.sectionSubtitle.classes)}
+                style={{ color: data.textColor }}
+              >
+                {step.title}
+              </h3>
+              <p
+                className={cn(typography.bodyText.classes)}
+                style={{ color: data.textColor }}
+              >
+                {step.description}
+              </p>
+            </div>
+          ))}
+        </div>
+
+        <div className={sectionDefaults.steps.buttonContainer}>
+          <Button {...data.button} />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/Technology.tsx
+++ b/src/components/sections/Technology.tsx
@@ -1,0 +1,74 @@
+import Image from 'next/image';
+import { cn } from '@/lib/utils';
+import { TechnologyData } from '@/types/lp-config';
+import { Button } from '@/components/ui/Button';
+import { sectionDefaults } from '@/config/sections';
+import { typography } from '@/config/typography';
+
+interface TechnologyProps {
+  data: TechnologyData;
+}
+
+export function Technology({ data }: TechnologyProps) {
+  const sectionStyle = {
+    ...(data.backgroundColor && { backgroundColor: data.backgroundColor }),
+    ...(data.textColor && { color: data.textColor }),
+  } as React.CSSProperties;
+
+  return (
+    <section className={sectionDefaults.technology.classes} style={sectionStyle}>
+      <div className={sectionDefaults.technology.container}>
+        <div className={sectionDefaults.technology.titleContainer}>
+          <h2
+            className={cn(typography.sectionTitle.classes)}
+            style={{ color: data.textColor }}
+          >
+            {data.title}
+          </h2>
+        </div>
+
+        <div className={sectionDefaults.technology.contentLayout}>
+          <div className={sectionDefaults.technology.itemsContainer}>
+            {data.items.map((item, index) => (
+              <div key={index} className={sectionDefaults.technology.item}>
+                <span className={sectionDefaults.technology.iconContainer}>
+                  {item.icon}
+                </span>
+                <div className={sectionDefaults.technology.textContainer}>
+                  <h3
+                    className={cn(typography.sectionSubtitle.classes, 'mb-2')}
+                    style={{ color: data.textColor }}
+                  >
+                    {item.title}
+                  </h3>
+                  <p
+                    className={cn(typography.bodyText.classes, 'mb-0')}
+                    style={{ color: data.textColor }}
+                  >
+                    {item.description}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className={sectionDefaults.technology.imageContainer}>
+            <div className="relative w-full max-w-md mx-auto aspect-square rounded-2xl overflow-hidden shadow-xl">
+              <Image
+                src={data.image.src}
+                alt={data.image.alt}
+                fill
+                className="object-cover"
+                sizes="(max-width: 768px) 100vw, 400px"
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className={sectionDefaults.technology.buttonContainer}>
+          <Button {...data.button} />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/Testimonials.tsx
+++ b/src/components/sections/Testimonials.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useState, useRef } from 'react';
+import { cn } from '@/lib/utils';
+import { TestimonialsData } from '@/types/lp-config';
+import { sectionDefaults } from '@/config/sections';
+import { typography } from '@/config/typography';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+interface TestimonialsProps {
+  data: TestimonialsData;
+}
+
+export function Testimonials({ data }: TestimonialsProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(true);
+
+  const sectionStyle = {
+    ...(data.backgroundColor && { backgroundColor: data.backgroundColor }),
+    ...(data.textColor && { color: data.textColor }),
+  } as React.CSSProperties;
+
+  const checkScroll = () => {
+    if (scrollRef.current) {
+      const { scrollLeft, scrollWidth, clientWidth } = scrollRef.current;
+      setCanScrollLeft(scrollLeft > 0);
+      setCanScrollRight(scrollLeft < scrollWidth - clientWidth - 10);
+    }
+  };
+
+  const scroll = (direction: 'left' | 'right') => {
+    if (scrollRef.current) {
+      const scrollAmount = scrollRef.current.clientWidth / 3;
+      scrollRef.current.scrollBy({
+        left: direction === 'left' ? -scrollAmount : scrollAmount,
+        behavior: 'smooth',
+      });
+      setTimeout(checkScroll, 300);
+    }
+  };
+
+  return (
+    <section className={sectionDefaults.testimonials.classes} style={sectionStyle}>
+      <div className={sectionDefaults.testimonials.container}>
+        <div className={sectionDefaults.testimonials.titleContainer}>
+          <h2
+            className={cn(typography.sectionTitle.classes)}
+            style={{ color: data.textColor }}
+          >
+            {data.title}
+          </h2>
+        </div>
+
+        <div className={sectionDefaults.testimonials.carouselContainer}>
+          <div
+            ref={scrollRef}
+            className={sectionDefaults.testimonials.carouselTrack}
+            onScroll={checkScroll}
+          >
+            {data.videos.map((video, index) => (
+              <div key={index} className={sectionDefaults.testimonials.videoCard}>
+                <div className="relative w-full pt-[56.25%] rounded-lg overflow-hidden shadow-lg">
+                  <iframe
+                    src={video.embedUrl}
+                    title={video.title || `Depoimento ${index + 1}`}
+                    className="absolute inset-0 w-full h-full"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowFullScreen
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className={sectionDefaults.testimonials.navigationContainer}>
+            <button
+              onClick={() => scroll('left')}
+              disabled={!canScrollLeft}
+              className={cn(
+                sectionDefaults.testimonials.arrowButton,
+                !canScrollLeft && 'opacity-50 cursor-not-allowed'
+              )}
+              aria-label="Anterior"
+            >
+              <ChevronLeft className="w-6 h-6" />
+            </button>
+            <button
+              onClick={() => scroll('right')}
+              disabled={!canScrollRight}
+              className={cn(
+                sectionDefaults.testimonials.arrowButton,
+                !canScrollRight && 'opacity-50 cursor-not-allowed'
+              )}
+              aria-label="Próximo"
+            >
+              <ChevronRight className="w-6 h-6" />
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/config/sections.ts
+++ b/src/config/sections.ts
@@ -41,4 +41,76 @@ export const sectionDefaults = {
     iconInline: 'text-2xl flex-shrink-0 mt-1',
     buttonContainer: 'text-center',
   },
+
+  testimonials: {
+    structure: 'Título centralizado, carrossel de vídeos mostrando 3 por vez',
+    classes: 'py-12 md:py-16',
+    container: 'container-lp',
+    titleContainer: 'text-center mb-12',
+    carouselContainer: 'relative',
+    carouselTrack: 'flex gap-6 overflow-x-auto snap-x snap-mandatory scrollbar-hide',
+    videoCard: 'flex-none w-full md:w-[calc(33.333%-1rem)] snap-center',
+    navigationContainer: 'flex justify-center gap-4 mt-8',
+    arrowButton: 'p-2 rounded-full bg-gray-200 hover:bg-gray-300 transition-colors',
+  },
+
+  steps: {
+    structure: 'Título centralizado, 2 containers lado a lado com h3 e texto, botão centralizado abaixo',
+    classes: 'py-12 md:py-16',
+    container: 'container-lp',
+    titleContainer: 'text-center mb-12',
+    layout: 'grid grid-cols-1 md:grid-cols-2 gap-12 md:gap-16 mb-12',
+    stepContainer: 'text-center md:text-left space-y-4',
+    buttonContainer: 'text-center',
+  },
+
+  technology: {
+    structure: 'Título centralizado, 4 itens à esquerda e imagem à direita, botão centralizado abaixo',
+    classes: 'py-12 md:py-16',
+    container: 'container-lp',
+    titleContainer: 'text-center mb-12',
+    contentLayout: 'flex flex-col md:flex-row gap-12 md:gap-16 items-center mb-12',
+    itemsContainer: 'flex-1 space-y-6',
+    item: 'flex gap-4',
+    iconContainer: 'text-2xl flex-shrink-0 mt-1',
+    textContainer: 'flex-1',
+    imageContainer: 'flex-1 w-full md:w-auto',
+    buttonContainer: 'text-center',
+  },
+
+  about: {
+    structure: 'Imagem à esquerda, título h2 e texto à direita',
+    classes: 'py-12 md:py-16',
+    container: 'container-lp',
+    layout: 'flex flex-col md:flex-row gap-12 md:gap-16 items-center',
+    imageContainer: 'flex-1 w-full md:w-auto',
+    textContainer: 'flex-1 space-y-6 text-center md:text-left',
+  },
+
+  faq: {
+    structure: 'Título centralizado, accordion abaixo',
+    classes: 'py-12 md:py-16',
+    container: 'container-lp',
+    titleContainer: 'text-center mb-12',
+    accordionContainer: 'max-w-3xl mx-auto space-y-4',
+    accordionItem: 'border border-gray-200 rounded-lg overflow-hidden',
+    accordionTrigger: 'w-full text-left p-6 flex justify-between items-center hover:bg-gray-50 transition-colors',
+    accordionContent: 'px-6 pb-6',
+  },
+
+  ctaFinal: {
+    structure: 'Título h1, subtítulo h3 e botão centralizados verticalmente',
+    classes: 'py-16 md:py-24',
+    container: 'container-lp',
+    contentContainer: 'max-w-3xl mx-auto text-center space-y-6',
+  },
+
+  footer: {
+    structure: 'Instagram e texto à esquerda, link à direita',
+    classes: 'py-8 border-t',
+    container: 'container-lp',
+    layout: 'flex flex-col md:flex-row justify-between items-center gap-6',
+    leftContainer: 'flex flex-col items-center md:items-start gap-2',
+    rightContainer: 'text-center md:text-right',
+  },
 };

--- a/src/types/lp-config.ts
+++ b/src/types/lp-config.ts
@@ -9,11 +9,33 @@ export interface MetaData {
   favicon?: string;
 }
 
-export type SectionData = HeaderData | HeroData | BenefitsData | ServicesData;
+export type SectionData =
+  | HeaderData
+  | HeroData
+  | BenefitsData
+  | ServicesData
+  | TestimonialsData
+  | StepsData
+  | TechnologyData
+  | AboutData
+  | FAQData
+  | CTAFinalData
+  | FooterData;
 
 export interface BaseSection {
   id: string;
-  type: 'header' | 'hero' | 'benefits' | 'services';
+  type:
+    | 'header'
+    | 'hero'
+    | 'benefits'
+    | 'services'
+    | 'testimonials'
+    | 'steps'
+    | 'technology'
+    | 'about'
+    | 'faq'
+    | 'ctaFinal'
+    | 'footer';
   backgroundColor?: string;
   textColor?: string;
 }
@@ -60,6 +82,81 @@ export interface ServicesData extends BaseSection {
 export interface ServiceItem {
   icon: string;
   text: string;
+}
+
+export interface TestimonialsData extends BaseSection {
+  type: 'testimonials';
+  title: string;
+  videos: VideoEmbed[];
+}
+
+export interface VideoEmbed {
+  embedUrl: string;
+  title?: string;
+}
+
+export interface StepsData extends BaseSection {
+  type: 'steps';
+  title: string;
+  steps: StepItem[];
+  button: ButtonData;
+}
+
+export interface StepItem {
+  title: string;
+  description: string;
+}
+
+export interface TechnologyData extends BaseSection {
+  type: 'technology';
+  title: string;
+  items: TechItem[];
+  image: ImageData;
+  button: ButtonData;
+}
+
+export interface TechItem {
+  icon: string;
+  title: string;
+  description: string;
+}
+
+export interface AboutData extends BaseSection {
+  type: 'about';
+  title: string;
+  description: string;
+  image: ImageData;
+}
+
+export interface FAQData extends BaseSection {
+  type: 'faq';
+  title: string;
+  items: FAQItem[];
+}
+
+export interface FAQItem {
+  question: string;
+  answer: string;
+}
+
+export interface CTAFinalData extends BaseSection {
+  type: 'ctaFinal';
+  title: string;
+  subtitle: string;
+  button: ButtonData;
+}
+
+export interface FooterData extends BaseSection {
+  type: 'footer';
+  instagram: {
+    url: string;
+    text: string;
+  };
+  copyright: string;
+  legalLink: {
+    text: string;
+    href: string;
+  };
 }
 
 export interface ButtonData {


### PR DESCRIPTION
## Summary
- implement more section types for the landing page
- add matching React components
- extend config defaults and types
- provide sample data with the new sections
- tweak benefits layout
- update CSS utilities

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: cannot find module 'next')*
- `npm run format` *(fails: cannot find package 'prettier-plugin-tailwindcss')*

------
https://chatgpt.com/codex/tasks/task_e_685092b6e8988329afe01697dbf25eeb