### PR TITLE
Fix section ids for navigation

### DIFF
--- a/src/components/sections/About.tsx
+++ b/src/components/sections/About.tsx
@@ -15,7 +15,7 @@ export function About({ data }: AboutProps) {
   } as React.CSSProperties;
 
   return (
-    <section className={sectionDefaults.about.classes} style={sectionStyle}>
+    <section id={data.id} className={sectionDefaults.about.classes} style={sectionStyle}>
       <div className={sectionDefaults.about.container}>
         <div className={sectionDefaults.about.layout}>
           <div className={sectionDefaults.about.imageContainer}>

--- a/src/components/sections/Benefits.tsx
+++ b/src/components/sections/Benefits.tsx
@@ -14,7 +14,7 @@ export function Benefits({ data }: BenefitsProps) {
   } as React.CSSProperties;
 
   return (
-    <section className={sectionDefaults.benefits.classes} style={sectionStyle}>
+    <section id={data.id} className={sectionDefaults.benefits.classes} style={sectionStyle}>
       <div className={sectionDefaults.benefits.container}>
         {/* Título centralizado */}
         <div className={sectionDefaults.benefits.titleContainer}>

--- a/src/components/sections/CTAFinal.tsx
+++ b/src/components/sections/CTAFinal.tsx
@@ -15,7 +15,7 @@ export function CTAFinal({ data }: CTAFinalProps) {
   } as React.CSSProperties;
 
   return (
-    <section className={sectionDefaults.ctaFinal.classes} style={sectionStyle}>
+    <section id={data.id} className={sectionDefaults.ctaFinal.classes} style={sectionStyle}>
       <div className={sectionDefaults.ctaFinal.container}>
         <div className={sectionDefaults.ctaFinal.contentContainer}>
           <h2

--- a/src/components/sections/FAQ.tsx
+++ b/src/components/sections/FAQ.tsx
@@ -24,7 +24,7 @@ export function FAQ({ data }: FAQProps) {
   };
 
   return (
-    <section className={sectionDefaults.faq.classes} style={sectionStyle}>
+    <section id={data.id} className={sectionDefaults.faq.classes} style={sectionStyle}>
       <div className={sectionDefaults.faq.container}>
         <div className={sectionDefaults.faq.titleContainer}>
           <h2

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -16,7 +16,7 @@ export function Hero({ data }: HeroProps) {
   };
 
   return (
-    <section className={sectionDefaults.hero.classes} style={sectionStyle}>
+    <section id={data.id} className={sectionDefaults.hero.classes} style={sectionStyle}>
       <div className={sectionDefaults.hero.container}>
         <div className={sectionDefaults.hero.layout}>
           {/* Container 1: Texto (vertical com espaçamento entre elementos) */}

--- a/src/components/sections/Services.tsx
+++ b/src/components/sections/Services.tsx
@@ -16,7 +16,7 @@ export function Services({ data }: ServicesProps) {
   } as React.CSSProperties;
 
   return (
-    <section className={sectionDefaults.services.classes} style={sectionStyle}>
+    <section id={data.id} className={sectionDefaults.services.classes} style={sectionStyle}>
       <div className={sectionDefaults.services.container}>
         {/* Título centralizado */}
         <div className={sectionDefaults.services.titleContainer}>

--- a/src/components/sections/Steps.tsx
+++ b/src/components/sections/Steps.tsx
@@ -15,7 +15,7 @@ export function Steps({ data }: StepsProps) {
   } as React.CSSProperties;
 
   return (
-    <section className={sectionDefaults.steps.classes} style={sectionStyle}>
+    <section id={data.id} className={sectionDefaults.steps.classes} style={sectionStyle}>
       <div className={sectionDefaults.steps.container}>
         <div className={sectionDefaults.steps.titleContainer}>
           <h2

--- a/src/components/sections/Technology.tsx
+++ b/src/components/sections/Technology.tsx
@@ -16,7 +16,7 @@ export function Technology({ data }: TechnologyProps) {
   } as React.CSSProperties;
 
   return (
-    <section className={sectionDefaults.technology.classes} style={sectionStyle}>
+    <section id={data.id} className={sectionDefaults.technology.classes} style={sectionStyle}>
       <div className={sectionDefaults.technology.container}>
         <div className={sectionDefaults.technology.titleContainer}>
           <h2

--- a/src/components/sections/Testimonials.tsx
+++ b/src/components/sections/Testimonials.tsx
@@ -41,7 +41,7 @@ export function Testimonials({ data }: TestimonialsProps) {
   };
 
   return (
-    <section className={sectionDefaults.testimonials.classes} style={sectionStyle}>
+    <section id={data.id} className={sectionDefaults.testimonials.classes} style={sectionStyle}>
       <div className={sectionDefaults.testimonials.container}>
         <div className={sectionDefaults.testimonials.titleContainer}>
           <h2


### PR DESCRIPTION
## Summary
- add `id` prop on each section for anchor navigation

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: cannot find module 'next')*

------
https://chatgpt.com/codex/tasks/task_e_6851a0bf66748329bd53e82a9730b2ac