### PR TITLE
Add light theme components and utils

### DIFF
--- a/src/components/light/BenefitsLight.tsx
+++ b/src/components/light/BenefitsLight.tsx
@@ -1,0 +1,31 @@
+import { BenefitsData } from '@/types/lp-config';
+
+interface BenefitsLightProps {
+  data: BenefitsData;
+}
+
+export function BenefitsLight({ data }: BenefitsLightProps) {
+  return (
+    <section
+      id={data.id}
+      className="benefits-light"
+      style={{
+        '--bg': data.backgroundColor || '#ffffff',
+        '--color': data.textColor || '#1a1a1a',
+      } as React.CSSProperties}
+    >
+      <div className="container">
+        <h2>{data.title}</h2>
+        <div className="benefits-grid">
+          {data.items.map((item, index) => (
+            <div key={index} className="benefit-card">
+              <span className="benefit-icon">{item.icon}</span>
+              <h3>{item.title}</h3>
+              <p>{item.description}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/light/HeroLight.tsx
+++ b/src/components/light/HeroLight.tsx
@@ -1,0 +1,54 @@
+import Image from 'next/image';
+import { HeroData } from '@/types/lp-config';
+
+interface HeroLightProps {
+  data: HeroData;
+}
+
+export function HeroLight({ data }: HeroLightProps) {
+  return (
+    <section
+      id={data.id}
+      className="hero-light"
+      style={{
+        '--bg': data.backgroundColor || '#f8f9fa',
+        '--color': data.textColor || '#1a1a1a',
+      } as React.CSSProperties}
+    >
+      <div className="hero-content">
+        <div className="hero-text">
+          <h1>{data.title}</h1>
+          <p>{data.description}</p>
+          <div className="hero-buttons">
+            <a
+              href={data.primaryButton.href}
+              className={`btn btn-${data.primaryButton.variant || 'primary'}`}
+            >
+              {data.primaryButton.text}
+            </a>
+            {data.secondaryButton && (
+              <a
+                href={data.secondaryButton.href}
+                className={`btn btn-${
+                  data.secondaryButton.variant || 'outline'
+                }`}
+              >
+                {data.secondaryButton.text}
+              </a>
+            )}
+          </div>
+        </div>
+        <div className="hero-image">
+          <Image
+            src={data.image.src}
+            alt={data.image.alt}
+            width={600}
+            height={400}
+            priority
+            className="rounded-lg"
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/light/ServicesLight.tsx
+++ b/src/components/light/ServicesLight.tsx
@@ -1,0 +1,51 @@
+import Image from 'next/image';
+import { ServicesData } from '@/types/lp-config';
+
+interface ServicesLightProps {
+  data: ServicesData;
+}
+
+export function ServicesLight({ data }: ServicesLightProps) {
+  return (
+    <section
+      id={data.id}
+      className="services-light"
+      style={{
+        '--bg': data.backgroundColor || '#f8f9fa',
+        '--color': data.textColor || '#1a1a1a',
+      } as React.CSSProperties}
+    >
+      <div className="container">
+        <h2>{data.title}</h2>
+        <div className="services-content">
+          <div className="services-image">
+            <Image
+              src={data.image.src}
+              alt={data.image.alt}
+              width={400}
+              height={400}
+              className="rounded-lg"
+            />
+          </div>
+          <div className="services-list">
+            {data.items.map((item, index) => (
+              <div key={index} className="service-item">
+                <span>{item.icon}</span>
+                <p
+                  dangerouslySetInnerHTML={{
+                    __html: item.text.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>'),
+                  }}
+                />
+              </div>
+            ))}
+            {data.button && (
+              <a href={data.button.href} className={`btn btn-${data.button.variant || 'primary'}`}>
+                {data.button.text}
+              </a>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/light/light-components.css
+++ b/src/components/light/light-components.css
@@ -1,0 +1,167 @@
+/* Base container */
+.container {
+  max-width: 75rem;
+  margin: 0 auto;
+  padding: 0 1rem;
+}
+
+/* Hero Light */
+.hero-light {
+  background-color: var(--bg);
+  color: var(--color);
+  padding: 3rem 0;
+}
+
+.hero-content {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 3rem;
+  align-items: center;
+  max-width: 75rem;
+  margin: 0 auto;
+  padding: 0 1rem;
+}
+
+.hero-text h1 {
+  font-size: 2.5rem;
+  font-weight: 700;
+  line-height: 1.2;
+  margin-bottom: 1rem;
+}
+
+.hero-text p {
+  font-size: 1.25rem;
+  line-height: 1.5;
+  margin-bottom: 2rem;
+}
+
+.hero-buttons {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.hero-image img {
+  width: 100%;
+  height: auto;
+}
+
+/* Benefits Light */
+.benefits-light {
+  background-color: var(--bg);
+  color: var(--color);
+  padding: 3rem 0;
+}
+
+.benefits-light h2 {
+  text-align: center;
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 3rem;
+}
+
+.benefits-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 2rem;
+}
+
+.benefit-card {
+  text-align: center;
+  padding: 1.5rem;
+}
+
+.benefit-icon {
+  font-size: 3rem;
+  display: block;
+  margin-bottom: 1rem;
+}
+
+.benefit-card h3 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+/* Services Light */
+.services-light {
+  background-color: var(--bg);
+  color: var(--color);
+  padding: 3rem 0;
+}
+
+.services-light h2 {
+  text-align: center;
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 3rem;
+}
+
+.services-content {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 3rem;
+  align-items: center;
+}
+
+.services-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.service-item {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.service-item span {
+  font-size: 1.5rem;
+  flex-shrink: 0;
+}
+
+/* Buttons */
+.btn {
+  display: inline-block;
+  padding: 0.75rem 2rem;
+  border-radius: 0.5rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: all 0.2s;
+}
+
+.btn-primary {
+  background-color: #ff6600;
+  color: white;
+}
+
+.btn-primary:hover {
+  background-color: #e55a00;
+}
+
+.btn-outline {
+  border: 2px solid currentColor;
+  color: inherit;
+}
+
+.btn-outline:hover {
+  opacity: 0.8;
+}
+
+/* Responsive */
+@media (min-width: 768px) {
+  .hero-content,
+  .services-content {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .hero-text,
+  .services-light h2 {
+    text-align: left;
+  }
+
+  .hero-buttons {
+    justify-content: flex-start;
+  }
+}

--- a/src/hooks/useOptimizedLoad.ts
+++ b/src/hooks/useOptimizedLoad.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+export function useOptimizedLoad() {
+  const [isClient, setIsClient] = useState(false);
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    setIsClient(true);
+
+    // Carrega componentes pesados após o initial load
+    const timer = setTimeout(() => {
+      setIsVisible(true);
+    }, 100);
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  return { isClient, isVisible };
+}

--- a/src/lib/optimize.ts
+++ b/src/lib/optimize.ts
@@ -1,0 +1,38 @@
+/**
+ * Otimizações de performance
+ */
+
+// Debounce para eventos de scroll/resize
+export function debounce<T extends (...args: any[]) => any>(
+  func: T,
+  wait: number
+): (...args: Parameters<T>) => void {
+  let timeout: NodeJS.Timeout;
+  return function executedFunction(...args: Parameters<T>) {
+    const later = () => {
+      clearTimeout(timeout);
+      func(...args);
+    };
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+  };
+}
+
+// Lazy load de imagens com Intersection Observer
+export function lazyLoadImages() {
+  if (typeof window === 'undefined') return;
+
+  const images = document.querySelectorAll('img[data-lazy]');
+  const imageObserver = new IntersectionObserver((entries, observer) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        const img = entry.target as HTMLImageElement;
+        img.src = img.dataset.lazy || '';
+        img.removeAttribute('data-lazy');
+        observer.unobserve(img);
+      }
+    });
+  });
+
+  images.forEach((img) => imageObserver.observe(img));
+}


### PR DESCRIPTION
## Summary
- add HeroLight, BenefitsLight and ServicesLight components
- include CSS for light-themed components
- add hook `useOptimizedLoad`
- add optimization helpers with debounce and lazy image loading

## Testing
- `npx prettier --write src/components/light/HeroLight.tsx` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails with missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685c9426791c83299746c1358dce3202