### PR TITLE
Add gallery, pricing and contact light components

### DIFF
--- a/src/components/light/ContactLight.tsx
+++ b/src/components/light/ContactLight.tsx
@@ -1,0 +1,67 @@
+import { ContactData } from '@/types/lp-config';
+
+interface ContactLightProps {
+  data: ContactData;
+}
+
+export function ContactLight({ data }: ContactLightProps) {
+  return (
+    <section 
+      id={data.id}
+      className="contact-light"
+      style={{
+        '--bg': data.backgroundColor || '#ffffff',
+        '--color': data.textColor || '#1a1a1a',
+      } as React.CSSProperties}
+    >
+      <div className="container">
+        <h2>{data.title}</h2>
+        {data.subtitle && <p className="contact-subtitle">{data.subtitle}</p>}
+        
+        <div className="contact-content">
+          <form className="contact-form" action={data.formAction} method="POST">
+            {data.fields.map((field, index) => (
+              <div key={index} className="form-group">
+                <label htmlFor={field.name}>{field.label}</label>
+                {field.type === 'textarea' ? (
+                  <textarea
+                    id={field.name}
+                    name={field.name}
+                    required={field.required}
+                    placeholder={field.placeholder}
+                    rows={4}
+                  />
+                ) : (
+                  <input
+                    type={field.type}
+                    id={field.name}
+                    name={field.name}
+                    required={field.required}
+                    placeholder={field.placeholder}
+                  />
+                )}
+              </div>
+            ))}
+            <button type="submit" className="btn btn-primary btn-block">
+              {data.submitButton.text}
+            </button>
+          </form>
+          
+          {data.info && (
+            <div className="contact-info">
+              {data.info.map((item, index) => (
+                <div key={index} className="info-item">
+                  <span className="info-icon">{item.icon}</span>
+                  <div>
+                    <h4>{item.label}</h4>
+                    <p>{item.value}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/light/GalleryLight.tsx
+++ b/src/components/light/GalleryLight.tsx
@@ -1,0 +1,38 @@
+import Image from 'next/image';
+import { GalleryData } from '@/types/lp-config';
+
+interface GalleryLightProps {
+  data: GalleryData;
+}
+
+export function GalleryLight({ data }: GalleryLightProps) {
+  return (
+    <section 
+      id={data.id}
+      className="gallery-light"
+      style={{
+        '--bg': data.backgroundColor || '#ffffff',
+        '--color': data.textColor || '#1a1a1a',
+      } as React.CSSProperties}
+    >
+      <div className="container">
+        <h2>{data.title}</h2>
+        {data.subtitle && <p className="gallery-subtitle">{data.subtitle}</p>}
+        <div className="gallery-grid">
+          {data.images.map((image, index) => (
+            <div key={index} className="gallery-item">
+              <Image
+                src={image.src}
+                alt={image.alt}
+                width={400}
+                height={300}
+                className="gallery-image"
+                loading="lazy"
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/light/PricingLight.tsx
+++ b/src/components/light/PricingLight.tsx
@@ -1,0 +1,49 @@
+import { PricingData } from '@/types/lp-config';
+
+interface PricingLightProps {
+  data: PricingData;
+}
+
+export function PricingLight({ data }: PricingLightProps) {
+  return (
+    <section 
+      id={data.id}
+      className="pricing-light"
+      style={{
+        '--bg': data.backgroundColor || '#f8f9fa',
+        '--color': data.textColor || '#1a1a1a',
+      } as React.CSSProperties}
+    >
+      <div className="container">
+        <h2>{data.title}</h2>
+        {data.subtitle && <p className="pricing-subtitle">{data.subtitle}</p>}
+        <div className="pricing-grid">
+          {data.plans.map((plan, index) => (
+            <div 
+              key={index} 
+              className={`pricing-card ${plan.featured ? 'featured' : ''}`}
+            >
+              <h3>{plan.name}</h3>
+              <div className="price">
+                <span className="currency">{plan.currency}</span>
+                <span className="amount">{plan.price}</span>
+                <span className="period">/{plan.period}</span>
+              </div>
+              <ul className="features">
+                {plan.features.map((feature, idx) => (
+                  <li key={idx}>{feature}</li>
+                ))}
+              </ul>
+              <a 
+                href={plan.button.href}
+                className={`btn btn-${plan.button.variant || 'primary'} btn-block`}
+              >
+                {plan.button.text}
+              </a>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/light/additional-styles.css
+++ b/src/components/light/additional-styles.css
@@ -1,0 +1,207 @@
+/* Gallery Light */
+.gallery-light {
+  background-color: var(--bg);
+  color: var(--color);
+  padding: 3rem 0;
+}
+
+.gallery-light h2 {
+  text-align: center;
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+
+.gallery-subtitle {
+  text-align: center;
+  font-size: 1.125rem;
+  opacity: 0.8;
+  margin-bottom: 3rem;
+}
+
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1.5rem;
+}
+
+.gallery-item {
+  overflow: hidden;
+  border-radius: 0.5rem;
+  transition: transform 0.3s;
+}
+
+.gallery-item:hover {
+  transform: scale(1.05);
+}
+
+.gallery-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+/* Pricing Light */
+.pricing-light {
+  background-color: var(--bg);
+  color: var(--color);
+  padding: 3rem 0;
+}
+
+.pricing-light h2 {
+  text-align: center;
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+
+.pricing-subtitle {
+  text-align: center;
+  font-size: 1.125rem;
+  opacity: 0.8;
+  margin-bottom: 3rem;
+}
+
+.pricing-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+  max-width: 1000px;
+  margin: 0 auto;
+}
+
+.pricing-card {
+  background: white;
+  border: 1px solid #e5e5e5;
+  border-radius: 0.75rem;
+  padding: 2rem;
+  text-align: center;
+  transition: all 0.3s;
+}
+
+.pricing-card.featured {
+  border-color: #ff6600;
+  transform: scale(1.05);
+  box-shadow: 0 10px 30px rgba(0,0,0,0.1);
+}
+
+.pricing-card h3 {
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.price {
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  margin-bottom: 2rem;
+}
+
+.currency {
+  font-size: 1.25rem;
+  margin-right: 0.25rem;
+}
+
+.amount {
+  font-size: 3rem;
+  font-weight: 700;
+}
+
+.period {
+  font-size: 1rem;
+  opacity: 0.8;
+  margin-left: 0.25rem;
+}
+
+.features {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 2rem;
+}
+
+.features li {
+  padding: 0.5rem 0;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+/* Contact Light */
+.contact-light {
+  background-color: var(--bg);
+  color: var(--color);
+  padding: 3rem 0;
+}
+
+.contact-light h2 {
+  text-align: center;
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+
+.contact-subtitle {
+  text-align: center;
+  font-size: 1.125rem;
+  opacity: 0.8;
+  margin-bottom: 3rem;
+}
+
+.contact-content {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 3rem;
+  max-width: 1000px;
+  margin: 0 auto;
+}
+
+.contact-form {
+  background: white;
+  padding: 2rem;
+  border-radius: 0.75rem;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.05);
+}
+
+.form-group {
+  margin-bottom: 1.5rem;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+}
+
+.form-group input,
+.form-group textarea {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid #e5e5e5;
+  border-radius: 0.375rem;
+  font-size: 1rem;
+}
+
+.contact-info {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.info-item {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.info-icon {
+  font-size: 1.5rem;
+  flex-shrink: 0;
+}
+
+.btn-block {
+  width: 100%;
+}
+
+@media (min-width: 768px) {
+  .contact-content {
+    grid-template-columns: 2fr 1fr;
+  }
+}

--- a/src/types/lp-config-extended.ts
+++ b/src/types/lp-config-extended.ts
@@ -1,0 +1,52 @@
+import { BaseSection, ButtonData, ImageData } from './lp-config';
+
+// Gallery Section
+export interface GalleryData extends BaseSection {
+  type: 'gallery';
+  title: string;
+  subtitle?: string;
+  images: ImageData[];
+}
+
+// Pricing Section
+export interface PricingData extends BaseSection {
+  type: 'pricing';
+  title: string;
+  subtitle?: string;
+  plans: PricingPlan[];
+}
+
+export interface PricingPlan {
+  name: string;
+  price: string;
+  currency: string;
+  period: string;
+  featured?: boolean;
+  features: string[];
+  button: ButtonData;
+}
+
+// Contact Section
+export interface ContactData extends BaseSection {
+  type: 'contact';
+  title: string;
+  subtitle?: string;
+  formAction: string;
+  fields: FormField[];
+  submitButton: ButtonData;
+  info?: ContactInfo[];
+}
+
+export interface FormField {
+  type: 'text' | 'email' | 'tel' | 'textarea';
+  name: string;
+  label: string;
+  placeholder?: string;
+  required?: boolean;
+}
+
+export interface ContactInfo {
+  icon: string;
+  label: string;
+  value: string;
+}


### PR DESCRIPTION
## Summary
- implement `GalleryLight`, `PricingLight`, and `ContactLight` components
- define supporting types in `lp-config-extended`
- add related CSS styles

## Testing
- `npm run format` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685c96807d348329a5ee5293d49e925e