### PR TITLE
Add theme configuration and light landing page

### DIFF
--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { createContext, useContext, useEffect } from 'react';
+import { Theme, themes } from '@/config/themes';
+
+interface ThemeContextType {
+  theme: Theme;
+  setTheme: (themeName: string) => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export function ThemeProvider({
+  children,
+  defaultTheme = 'default',
+}: {
+  children: React.ReactNode;
+  defaultTheme?: string;
+}) {
+  const theme = themes[defaultTheme] || themes.default;
+
+  useEffect(() => {
+    // Aplicar variáveis CSS do tema
+    const root = document.documentElement;
+    root.style.setProperty('--color-primary', theme.colors.primary);
+    root.style.setProperty('--color-secondary', theme.colors.secondary);
+    root.style.setProperty('--color-background', theme.colors.background);
+    root.style.setProperty('--color-text', theme.colors.text);
+    root.style.setProperty('--color-accent', theme.colors.accent);
+    root.style.setProperty('--font-heading', theme.fonts.heading);
+    root.style.setProperty('--font-body', theme.fonts.body);
+    root.style.setProperty('--spacing-section', theme.spacing.section);
+    root.style.setProperty('--spacing-container', theme.spacing.container);
+  }, [theme]);
+
+  const setTheme = (themeName: string) => {
+    // Para implementar troca dinâmica de tema
+    console.log('Theme change to:', themeName);
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within ThemeProvider');
+  }
+  return context;
+}

--- a/src/components/light/LandingPageLight.tsx
+++ b/src/components/light/LandingPageLight.tsx
@@ -1,0 +1,44 @@
+import dynamic from 'next/dynamic';
+import { LandingPageData } from '@/types/lp-config';
+import { ThemeProvider } from '@/components/ThemeProvider';
+
+// Import dos componentes light
+import { HeroLight } from './HeroLight';
+import { BenefitsLight } from './BenefitsLight';
+import { ServicesLight } from './ServicesLight';
+
+// Lazy load para componentes abaixo da dobra
+const GalleryLight = dynamic(() => import('./GalleryLight').then(m => ({ default: m.GalleryLight })));
+const PricingLight = dynamic(() => import('./PricingLight').then(m => ({ default: m.PricingLight })));
+const ContactLight = dynamic(() => import('./ContactLight').then(m => ({ default: m.ContactLight })));
+
+interface LandingPageLightProps {
+  data: LandingPageData & { theme?: string };
+}
+
+export function LandingPageLight({ data }: LandingPageLightProps) {
+  return (
+    <ThemeProvider defaultTheme={data.theme || 'default'}>
+      <div className="landing-page-light">
+        {data.sections.map((section) => {
+          switch (section.type) {
+            case 'hero':
+              return <HeroLight key={section.id} data={section as any} />;
+            case 'benefits':
+              return <BenefitsLight key={section.id} data={section as any} />;
+            case 'services':
+              return <ServicesLight key={section.id} data={section as any} />;
+            case 'gallery':
+              return <GalleryLight key={section.id} data={section as any} />;
+            case 'pricing':
+              return <PricingLight key={section.id} data={section as any} />;
+            case 'contact':
+              return <ContactLight key={section.id} data={section as any} />;
+            default:
+              return null;
+          }
+        })}
+      </div>
+    </ThemeProvider>
+  );
+}

--- a/src/config/themes.ts
+++ b/src/config/themes.ts
@@ -1,0 +1,93 @@
+export interface Theme {
+  name: string;
+  colors: {
+    primary: string;
+    secondary: string;
+    background: string;
+    text: string;
+    accent: string;
+  };
+  fonts: {
+    heading: string;
+    body: string;
+  };
+  spacing: {
+    section: string;
+    container: string;
+  };
+}
+
+export const themes: Record<string, Theme> = {
+  default: {
+    name: 'Default',
+    colors: {
+      primary: '#ff6600',
+      secondary: '#333333',
+      background: '#ffffff',
+      text: '#1a1a1a',
+      accent: '#007bff',
+    },
+    fonts: {
+      heading: 'Inter, sans-serif',
+      body: 'Inter, sans-serif',
+    },
+    spacing: {
+      section: '3rem',
+      container: '75rem',
+    },
+  },
+  dark: {
+    name: 'Dark',
+    colors: {
+      primary: '#ff6600',
+      secondary: '#ffffff',
+      background: '#1a1a1a',
+      text: '#ffffff',
+      accent: '#00d4ff',
+    },
+    fonts: {
+      heading: 'Inter, sans-serif',
+      body: 'Inter, sans-serif',
+    },
+    spacing: {
+      section: '3rem',
+      container: '75rem',
+    },
+  },
+  corporate: {
+    name: 'Corporate',
+    colors: {
+      primary: '#0066cc',
+      secondary: '#004499',
+      background: '#f8f9fa',
+      text: '#212529',
+      accent: '#28a745',
+    },
+    fonts: {
+      heading: 'Roboto, sans-serif',
+      body: 'Open Sans, sans-serif',
+    },
+    spacing: {
+      section: '4rem',
+      container: '80rem',
+    },
+  },
+  startup: {
+    name: 'Startup',
+    colors: {
+      primary: '#7c3aed',
+      secondary: '#a78bfa',
+      background: '#fafaf9',
+      text: '#18181b',
+      accent: '#10b981',
+    },
+    fonts: {
+      heading: 'Cal Sans, Inter, sans-serif',
+      body: 'Inter, sans-serif',
+    },
+    spacing: {
+      section: '5rem',
+      container: '70rem',
+    },
+  },
+};

--- a/src/config/variants.ts
+++ b/src/config/variants.ts
@@ -1,0 +1,66 @@
+export interface ComponentVariant {
+  name: string;
+  className: string;
+  styles?: React.CSSProperties;
+}
+
+export const heroVariants: ComponentVariant[] = [
+  {
+    name: 'default',
+    className: 'hero-default',
+  },
+  {
+    name: 'centered',
+    className: 'hero-centered',
+  },
+  {
+    name: 'reversed',
+    className: 'hero-reversed',
+  },
+  {
+    name: 'fullwidth',
+    className: 'hero-fullwidth',
+  },
+];
+
+export const buttonVariants: ComponentVariant[] = [
+  {
+    name: 'primary',
+    className: 'btn-primary',
+  },
+  {
+    name: 'secondary',
+    className: 'btn-secondary',
+  },
+  {
+    name: 'outline',
+    className: 'btn-outline',
+  },
+  {
+    name: 'ghost',
+    className: 'btn-ghost',
+  },
+  {
+    name: 'gradient',
+    className: 'btn-gradient',
+  },
+];
+
+export const sectionVariants: ComponentVariant[] = [
+  {
+    name: 'default',
+    className: 'section-default',
+  },
+  {
+    name: 'wave',
+    className: 'section-wave',
+  },
+  {
+    name: 'angle',
+    className: 'section-angle',
+  },
+  {
+    name: 'curve',
+    className: 'section-curve',
+  },
+];

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -1,0 +1,144 @@
+/* Variáveis CSS do tema */
+:root {
+  /* Cores */
+  --color-primary: #ff6600;
+  --color-secondary: #333333;
+  --color-background: #ffffff;
+  --color-text: #1a1a1a;
+  --color-accent: #007bff;
+  
+  /* Fontes */
+  --font-heading: 'Inter', sans-serif;
+  --font-body: 'Inter', sans-serif;
+  
+  /* Espaçamentos */
+  --spacing-section: 3rem;
+  --spacing-container: 75rem;
+  
+  /* Sombras */
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+  --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.1);
+  --shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.1);
+  --shadow-xl: 0 20px 25px rgba(0, 0, 0, 0.1);
+  
+  /* Transições */
+  --transition-fast: 150ms ease-in-out;
+  --transition-normal: 300ms ease-in-out;
+  --transition-slow: 500ms ease-in-out;
+}
+
+/* Variantes de Hero */
+.hero-centered {
+  text-align: center;
+}
+
+.hero-centered .hero-content {
+  grid-template-columns: 1fr;
+  max-width: 50rem;
+}
+
+.hero-reversed .hero-content {
+  direction: rtl;
+}
+
+.hero-reversed .hero-text {
+  direction: ltr;
+}
+
+.hero-fullwidth {
+  padding: 0;
+}
+
+.hero-fullwidth .hero-content {
+  max-width: 100%;
+  padding: 0;
+}
+
+/* Variantes de Botão */
+.btn-secondary {
+  background-color: var(--color-secondary);
+  color: white;
+}
+
+.btn-ghost {
+  background-color: transparent;
+  color: var(--color-primary);
+  border: none;
+}
+
+.btn-gradient {
+  background: linear-gradient(135deg, var(--color-primary), var(--color-accent));
+  color: white;
+}
+
+/* Variantes de Seção */
+.section-wave::before {
+  content: '';
+  position: absolute;
+  top: -50px;
+  left: 0;
+  width: 100%;
+  height: 50px;
+  background: inherit;
+  clip-path: polygon(0 0, 100% 0, 100% 100%, 0 calc(100% - 20px));
+}
+
+.section-angle {
+  position: relative;
+  padding-top: 5rem;
+  padding-bottom: 5rem;
+}
+
+.section-angle::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: inherit;
+  transform: skewY(-3deg);
+  transform-origin: top left;
+  z-index: -1;
+}
+
+.section-curve {
+  position: relative;
+  padding-top: 5rem;
+  padding-bottom: 5rem;
+}
+
+.section-curve::before {
+  content: '';
+  position: absolute;
+  top: -50px;
+  left: 0;
+  width: 100%;
+  height: 100px;
+  background: inherit;
+  border-radius: 50% 50% 0 0 / 100% 100% 0 0;
+}
+
+/* Animações */
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-fadeIn {
+  animation: fadeIn var(--transition-normal) ease-out;
+}
+
+/* Responsividade do tema */
+@media (prefers-color-scheme: dark) {
+  .auto-dark {
+    --color-background: #1a1a1a;
+    --color-text: #ffffff;
+  }
+}


### PR DESCRIPTION
## Summary
- add theme configuration and variants
- provide ThemeProvider component for CSS variable injection
- create light landing page component with theme support
- include theme/variant CSS

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: cannot find modules)*
- `npm run format:check` *(fails: missing prettier plugin)*

------
https://chatgpt.com/codex/tasks/task_e_685c97c4fa0483299609a9caa925f754