### PR TITLE
Change sections to default exports

### DIFF
--- a/src/components/sections/Benefits.tsx
+++ b/src/components/sections/Benefits.tsx
@@ -7,7 +7,7 @@ interface BenefitsProps {
   data: BenefitsData;
 }
 
-export function Benefits({ data }: BenefitsProps) {
+function Benefits({ data }: BenefitsProps) {
   const sectionStyle = {
     ...(data.backgroundColor && { backgroundColor: data.backgroundColor }),
     ...(data.textColor && { color: data.textColor }),
@@ -54,3 +54,5 @@ export function Benefits({ data }: BenefitsProps) {
     </section>
   );
 }
+
+export default Benefits;

--- a/src/components/sections/CTAFinal.tsx
+++ b/src/components/sections/CTAFinal.tsx
@@ -8,7 +8,7 @@ interface CTAFinalProps {
   data: CTAFinalData;
 }
 
-export function CTAFinal({ data }: CTAFinalProps) {
+function CTAFinal({ data }: CTAFinalProps) {
   const sectionStyle = {
     ...(data.backgroundColor && { backgroundColor: data.backgroundColor }),
     ...(data.textColor && { color: data.textColor }),
@@ -36,3 +36,5 @@ export function CTAFinal({ data }: CTAFinalProps) {
     </section>
   );
 }
+
+export default CTAFinal;

--- a/src/components/sections/FAQ.tsx
+++ b/src/components/sections/FAQ.tsx
@@ -11,7 +11,7 @@ interface FAQProps {
   data: FAQData;
 }
 
-export function FAQ({ data }: FAQProps) {
+function FAQ({ data }: FAQProps) {
   const [openIndex, setOpenIndex] = useState<number | null>(null);
 
   const sectionStyle = {
@@ -70,3 +70,5 @@ export function FAQ({ data }: FAQProps) {
     </section>
   );
 }
+
+export default FAQ;

--- a/src/components/sections/Footer.tsx
+++ b/src/components/sections/Footer.tsx
@@ -8,7 +8,7 @@ interface FooterProps {
   data: FooterData;
 }
 
-export function Footer({ data }: FooterProps) {
+function Footer({ data }: FooterProps) {
   const sectionStyle = {
     ...(data.backgroundColor && { backgroundColor: data.backgroundColor }),
     ...(data.textColor && { color: data.textColor }),
@@ -51,3 +51,5 @@ export function Footer({ data }: FooterProps) {
     </footer>
   );
 }
+
+export default Footer;

--- a/src/components/sections/Header.tsx
+++ b/src/components/sections/Header.tsx
@@ -12,7 +12,7 @@ interface HeaderProps {
   data: HeaderData;
 }
 
-export function Header({ data }: HeaderProps) {
+function Header({ data }: HeaderProps) {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   
   const containerStyle = {
@@ -132,3 +132,5 @@ export function Header({ data }: HeaderProps) {
     </header>
   );
 }
+
+export default Header;

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -9,7 +9,7 @@ interface HeroProps {
   data: HeroData;
 }
 
-export function Hero({ data }: HeroProps) {
+function Hero({ data }: HeroProps) {
   const sectionStyle = {
     ...(data.backgroundColor && { backgroundColor: data.backgroundColor }),
     ...(data.textColor && { color: data.textColor }),
@@ -64,3 +64,5 @@ export function Hero({ data }: HeroProps) {
     </section>
   );
 }
+
+export default Hero;

--- a/src/components/sections/Services.tsx
+++ b/src/components/sections/Services.tsx
@@ -9,7 +9,7 @@ interface ServicesProps {
   data: ServicesData;
 }
 
-export function Services({ data }: ServicesProps) {
+function Services({ data }: ServicesProps) {
   const sectionStyle = {
     ...(data.backgroundColor && { backgroundColor: data.backgroundColor }),
     ...(data.textColor && { color: data.textColor }),
@@ -72,3 +72,5 @@ export function Services({ data }: ServicesProps) {
     </section>
   );
 }
+
+export default Services;

--- a/src/components/sections/Steps.tsx
+++ b/src/components/sections/Steps.tsx
@@ -8,7 +8,7 @@ interface StepsProps {
   data: StepsData;
 }
 
-export function Steps({ data }: StepsProps) {
+function Steps({ data }: StepsProps) {
   const sectionStyle = {
     ...(data.backgroundColor && { backgroundColor: data.backgroundColor }),
     ...(data.textColor && { color: data.textColor }),
@@ -52,3 +52,5 @@ export function Steps({ data }: StepsProps) {
     </section>
   );
 }
+
+export default Steps;

--- a/src/components/sections/Technology.tsx
+++ b/src/components/sections/Technology.tsx
@@ -9,7 +9,7 @@ interface TechnologyProps {
   data: TechnologyData;
 }
 
-export function Technology({ data }: TechnologyProps) {
+function Technology({ data }: TechnologyProps) {
   const sectionStyle = {
     ...(data.backgroundColor && { backgroundColor: data.backgroundColor }),
     ...(data.textColor && { color: data.textColor }),
@@ -72,3 +72,5 @@ export function Technology({ data }: TechnologyProps) {
     </section>
   );
 }
+
+export default Technology;

--- a/src/components/sections/Testimonials.tsx
+++ b/src/components/sections/Testimonials.tsx
@@ -11,7 +11,7 @@ interface TestimonialsProps {
   data: TestimonialsData;
 }
 
-export function Testimonials({ data }: TestimonialsProps) {
+function Testimonials({ data }: TestimonialsProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(true);
@@ -102,3 +102,5 @@ export function Testimonials({ data }: TestimonialsProps) {
     </section>
   );
 }
+
+export default Testimonials;


### PR DESCRIPTION
## Summary
- switch various sections to default export style

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: cannot find packages)*
- `npm run format` *(fails: cannot find prettier plugin)*

------
https://chatgpt.com/codex/tasks/task_e_685d587851148329a54ce05381ec9c2d