### PR TITLE
Add light theme header and footer components

### DIFF
--- a/src/components/light/FooterLight.tsx
+++ b/src/components/light/FooterLight.tsx
@@ -1,0 +1,43 @@
+import { FooterData } from '@/types/lp-config';
+
+interface FooterLightProps {
+  data: FooterData;
+}
+
+export function FooterLight({ data }: FooterLightProps) {
+  return (
+    <footer
+      className="footer-light"
+      style={{
+        '--bg': data.backgroundColor || '#1a1a1a',
+        '--color': data.textColor || '#ffffff',
+      } as React.CSSProperties}
+    >
+      <div className="container footer-container">
+        <div className="footer-left">
+          <a
+            href={data.instagram.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="instagram-link"
+          >
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zM5.838 12a6.162 6.162 0 1 1 12.324 0 6.162 6.162 0 0 1-12.324 0zM12 16a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm4.965-10.405a1.44 1.44 0 1 1 2.881.001 1.44 1.44 0 0 1-2.881-.001z"/>
+            </svg>
+            <span>{data.instagram.text}</span>
+          </a>
+          <small className="copyright">{data.copyright}</small>
+        </div>
+
+        <div className="footer-right">
+          <a
+            href={data.legalLink.href}
+            className="legal-link"
+          >
+            {data.legalLink.text}
+          </a>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/light/HeaderLight.tsx
+++ b/src/components/light/HeaderLight.tsx
@@ -1,0 +1,71 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import { HeaderData, isTextLogo } from '@/types/lp-config';
+
+interface HeaderLightProps {
+  data: HeaderData;
+}
+
+export function HeaderLight({ data }: HeaderLightProps) {
+  return (
+    <header
+      className="header-light"
+      style={{
+        '--bg': data.backgroundColor || '#ffffff',
+        '--color': data.textColor || '#1a1a1a',
+      } as React.CSSProperties}
+    >
+      <div className="container header-container">
+        <div className="header-logo">
+          <Link href="/">
+            {isTextLogo(data.logo) ? (
+              <div className="logo-text">
+                <span className="logo-main">{data.logo.text}</span>
+                {data.logo.subtitle && (
+                  <span className="logo-subtitle">{data.logo.subtitle}</span>
+                )}
+              </div>
+            ) : (
+              <Image
+                src={data.logo.src}
+                alt={data.logo.alt}
+                width={180}
+                height={50}
+                className="logo-image"
+                priority
+              />
+            )}
+          </Link>
+        </div>
+
+        <nav className="header-nav">
+          {data.navigation.map((item, index) => (
+            <a
+              key={index}
+              href={item.href}
+              className="nav-link"
+            >
+              {item.label}
+            </a>
+          ))}
+          {data.phone && (
+            <a
+              href={data.phone.link}
+              className="nav-link nav-phone"
+            >
+              {data.phone.display}
+            </a>
+          )}
+        </nav>
+
+        <button className="mobile-menu-btn" aria-label="Menu">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <line x1="3" y1="6" x2="21" y2="6" />
+            <line x1="3" y1="12" x2="21" y2="12" />
+            <line x1="3" y1="18" x2="21" y2="18" />
+          </svg>
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/src/components/light/LandingPageLight.tsx
+++ b/src/components/light/LandingPageLight.tsx
@@ -6,6 +6,8 @@ import { ThemeProvider } from '@/components/ThemeProvider';
 import { HeroLight } from './HeroLight';
 import { BenefitsLight } from './BenefitsLight';
 import { ServicesLight } from './ServicesLight';
+import { HeaderLight } from './HeaderLight';
+import { FooterLight } from './FooterLight';
 
 // Lazy load para componentes abaixo da dobra
 const GalleryLight = dynamic(() => import('./GalleryLight').then(m => ({ default: m.GalleryLight })));
@@ -22,6 +24,8 @@ export function LandingPageLight({ data }: LandingPageLightProps) {
       <div className="landing-page-light">
         {data.sections.map((section) => {
           switch (section.type) {
+            case 'header':
+              return <HeaderLight key={section.id} data={section as any} />;
             case 'hero':
               return <HeroLight key={section.id} data={section as any} />;
             case 'benefits':
@@ -34,6 +38,8 @@ export function LandingPageLight({ data }: LandingPageLightProps) {
               return <PricingLight key={section.id} data={section as any} />;
             case 'contact':
               return <ContactLight key={section.id} data={section as any} />;
+            case 'footer':
+              return <FooterLight key={section.id} data={section as any} />;
             default:
               return null;
           }

--- a/src/components/light/light-components.css
+++ b/src/components/light/light-components.css
@@ -165,3 +165,157 @@
     justify-content: flex-start;
   }
 }
+
+/* Header Light */
+.header-light {
+  background-color: var(--bg);
+  color: var(--color);
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  padding: 1rem 0;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+}
+
+.header-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.header-logo {
+  flex-shrink: 0;
+}
+
+.logo-text {
+  display: flex;
+  flex-direction: column;
+}
+
+.logo-main {
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.logo-subtitle {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  opacity: 0.8;
+}
+
+.logo-image {
+  height: 3rem;
+  width: auto;
+}
+
+.header-nav {
+  display: none;
+  align-items: center;
+  gap: 2rem;
+}
+
+.nav-link {
+  text-decoration: none;
+  color: inherit;
+  font-weight: 500;
+  transition: opacity 0.2s;
+}
+
+.nav-link:hover {
+  opacity: 0.7;
+}
+
+.nav-phone {
+  font-weight: 700;
+}
+
+.mobile-menu-btn {
+  display: block;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 0.5rem;
+}
+
+/* Footer Light */
+.footer-light {
+  background-color: var(--bg);
+  color: var(--color);
+  padding: 2rem 0;
+  border-top: 1px solid rgba(255,255,255,0.1);
+}
+
+.footer-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.footer-left {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.instagram-link {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  text-decoration: none;
+  color: inherit;
+  transition: opacity 0.2s;
+}
+
+.instagram-link:hover {
+  opacity: 0.8;
+}
+
+.copyright {
+  font-size: 0.875rem;
+  opacity: 0.8;
+}
+
+.footer-right {
+  text-align: center;
+}
+
+.legal-link {
+  font-size: 0.875rem;
+  color: inherit;
+  opacity: 0.8;
+  transition: opacity 0.2s;
+}
+
+.legal-link:hover {
+  opacity: 1;
+  text-decoration: underline;
+}
+
+/* Responsive */
+@media (min-width: 768px) {
+  .header-nav {
+    display: flex;
+  }
+  
+  .mobile-menu-btn {
+    display: none;
+  }
+  
+  .footer-container {
+    flex-direction: row;
+    justify-content: space-between;
+  }
+  
+  .footer-left {
+    align-items: flex-start;
+  }
+  
+  .footer-right {
+    text-align: right;
+  }
+}


### PR DESCRIPTION
## Summary
- implement `HeaderLight` and `FooterLight`
- register header and footer in `LandingPageLight`
- add styling for light header and footer in `light-components.css`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dc51d5bdc8329b0dbc6334abc159c