### PR TITLE
Add light components for steps and technology

### DIFF
--- a/src/components/light/StepsLight.tsx
+++ b/src/components/light/StepsLight.tsx
@@ -1,0 +1,38 @@
+import { StepsData } from '@/types/lp-config';
+
+interface StepsLightProps {
+  data: StepsData;
+}
+
+export function StepsLight({ data }: StepsLightProps) {
+  return (
+    <section
+      id={data.id}
+      className="steps-light"
+      style={{
+        '--bg': data.backgroundColor || '#ffffff',
+        '--color': data.textColor || '#1a1a1a',
+      } as React.CSSProperties}
+    >
+      <div className="container">
+        <h2>{data.title}</h2>
+        <div className="steps-grid">
+          {data.steps.map((step, index) => (
+            <div key={index} className="step-item">
+              <h3>{step.title}</h3>
+              <p>{step.description}</p>
+            </div>
+          ))}
+        </div>
+        <div className="steps-button">
+          <a
+            href={data.button.href}
+            className={`btn btn-${data.button.variant || 'primary'}`}
+          >
+            {data.button.text}
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/light/TechnologyLight.tsx
+++ b/src/components/light/TechnologyLight.tsx
@@ -1,0 +1,53 @@
+import Image from 'next/image';
+import { TechnologyData } from '@/types/lp-config';
+
+interface TechnologyLightProps {
+  data: TechnologyData;
+}
+
+export function TechnologyLight({ data }: TechnologyLightProps) {
+  return (
+    <section
+      id={data.id}
+      className="technology-light"
+      style={{
+        '--bg': data.backgroundColor || '#f8f9fa',
+        '--color': data.textColor || '#1a1a1a',
+      } as React.CSSProperties}
+    >
+      <div className="container">
+        <h2>{data.title}</h2>
+        <div className="technology-content">
+          <div className="technology-items">
+            {data.items.map((item, index) => (
+              <div key={index} className="tech-item">
+                <span className="tech-icon">{item.icon}</span>
+                <div>
+                  <h3>{item.title}</h3>
+                  <p>{item.description}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="technology-image">
+            <Image
+              src={data.image.src}
+              alt={data.image.alt}
+              width={400}
+              height={400}
+              className="rounded-lg"
+            />
+          </div>
+        </div>
+        <div className="technology-button">
+          <a
+            href={data.button.href}
+            className={`btn btn-${data.button.variant || 'primary'}`}
+          >
+            {data.button.text}
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/light/additional-styles.css
+++ b/src/components/light/additional-styles.css
@@ -205,3 +205,108 @@
     grid-template-columns: 2fr 1fr;
   }
 }
+/* Steps Light */
+.steps-light {
+  background-color: var(--bg);
+  color: var(--color);
+  padding: 3rem 0;
+}
+
+.steps-light h2 {
+  text-align: center;
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 3rem;
+}
+
+.steps-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 3rem;
+  margin-bottom: 3rem;
+}
+
+.step-item h3 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.step-item p {
+  line-height: 1.6;
+  opacity: 0.9;
+}
+
+.steps-button {
+  text-align: center;
+}
+
+/* Technology Light */
+.technology-light {
+  background-color: var(--bg);
+  color: var(--color);
+  padding: 3rem 0;
+}
+
+.technology-light h2 {
+  text-align: center;
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 3rem;
+}
+
+.technology-content {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 3rem;
+  align-items: center;
+  margin-bottom: 3rem;
+}
+
+.technology-items {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.tech-item {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.tech-icon {
+  font-size: 2rem;
+  flex-shrink: 0;
+}
+
+.tech-item h3 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.tech-item p {
+  line-height: 1.6;
+  opacity: 0.9;
+}
+
+.technology-image img {
+  width: 100%;
+  height: auto;
+}
+
+.technology-button {
+  text-align: center;
+}
+
+/* Responsive */
+@media (min-width: 768px) {
+  .steps-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  
+  .technology-content {
+    grid-template-columns: 1fr 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add `StepsLight` component
- add `TechnologyLight` component
- extend light additional styles with steps and technology sections

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: cannot find module 'react' and others)*

------
https://chatgpt.com/codex/tasks/task_e_685dc6ecae88832991503802484ca990