### PR TITLE
Add About and CTA Final sections

### DIFF
--- a/src/components/light/AboutLight.tsx
+++ b/src/components/light/AboutLight.tsx
@@ -1,0 +1,49 @@
+import Image from 'next/image';
+import { AboutData } from '@/types/lp-config';
+
+interface AboutLightProps {
+  data: AboutData;
+}
+
+export function AboutLight({ data }: AboutLightProps) {
+  const hasImage = data.image !== undefined;
+  
+  return (
+    <section
+      id={data.id}
+      className="about-light"
+      style={{
+        '--bg': data.backgroundColor || '#ffffff',
+        '--color': data.textColor || '#1a1a1a',
+      } as React.CSSProperties}
+    >
+      <div className="container">
+        <div className={`about-content ${hasImage ? 'with-image' : 'text-only'}`}>
+          {hasImage && (
+            <div className="about-image">
+              <Image
+                src={data.image!.src}
+                alt={data.image!.alt}
+                width={400}
+                height={400}
+                className="rounded-lg"
+              />
+            </div>
+          )}
+          <div className="about-text">
+            <h2>{data.title}</h2>
+            <p className="about-description">{data.description}</p>
+            {data.button && (
+              <a
+                href={data.button.href}
+                className={`btn btn-${data.button.variant || 'primary'}`}
+              >
+                {data.button.text}
+              </a>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/light/CTAFinalLight.tsx
+++ b/src/components/light/CTAFinalLight.tsx
@@ -1,0 +1,31 @@
+import { CTAFinalData } from '@/types/lp-config';
+
+interface CTAFinalLightProps {
+  data: CTAFinalData;
+}
+
+export function CTAFinalLight({ data }: CTAFinalLightProps) {
+  return (
+    <section
+      id={data.id}
+      className="cta-final-light"
+      style={{
+        '--bg': data.backgroundColor || '#1a1a1a',
+        '--color': data.textColor || '#ffffff',
+      } as React.CSSProperties}
+    >
+      <div className="container">
+        <div className="cta-content">
+          <h2>{data.title}</h2>
+          {data.subtitle && <p className="cta-subtitle">{data.subtitle}</p>}
+          <a
+            href={data.button.href}
+            className={`btn btn-${data.button.variant || 'primary'}`}
+          >
+            {data.button.text}
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/light/LandingPageLight.tsx
+++ b/src/components/light/LandingPageLight.tsx
@@ -8,6 +8,8 @@ import { BenefitsLight } from './BenefitsLight';
 import { ServicesLight } from './ServicesLight';
 import { HeaderLight } from './HeaderLight';
 import { FooterLight } from './FooterLight';
+import { AboutLight } from './AboutLight';
+import { CTAFinalLight } from './CTAFinalLight';
 
 // Lazy load para componentes abaixo da dobra
 const GalleryLight = dynamic(() => import('./GalleryLight').then(m => ({ default: m.GalleryLight })));
@@ -32,12 +34,16 @@ export function LandingPageLight({ data }: LandingPageLightProps) {
               return <BenefitsLight key={section.id} data={section as any} />;
             case 'services':
               return <ServicesLight key={section.id} data={section as any} />;
+            case 'about':
+              return <AboutLight key={section.id} data={section as any} />;
             case 'gallery':
               return <GalleryLight key={section.id} data={section as any} />;
             case 'pricing':
               return <PricingLight key={section.id} data={section as any} />;
             case 'contact':
               return <ContactLight key={section.id} data={section as any} />;
+            case 'ctaFinal':
+              return <CTAFinalLight key={section.id} data={section as any} />;
             case 'footer':
               return <FooterLight key={section.id} data={section as any} />;
             default:

--- a/src/components/light/additional-styles.css
+++ b/src/components/light/additional-styles.css
@@ -205,3 +205,81 @@
     grid-template-columns: 2fr 1fr;
   }
 }
+
+/* About Light */
+.about-light {
+  background-color: var(--bg);
+  color: var(--color);
+  padding: 3rem 0;
+}
+
+.about-content {
+  display: grid;
+  gap: 3rem;
+  align-items: center;
+}
+
+.about-content.with-image {
+  grid-template-columns: 1fr;
+}
+
+.about-content.text-only {
+  max-width: 48rem;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.about-image img {
+  width: 100%;
+  height: auto;
+}
+
+.about-text h2 {
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 1.5rem;
+}
+
+.about-description {
+  font-size: 1.125rem;
+  line-height: 1.7;
+  margin-bottom: 2rem;
+  white-space: pre-line;
+}
+
+/* CTA Final Light */
+.cta-final-light {
+  background-color: var(--bg);
+  color: var(--color);
+  padding: 4rem 0;
+}
+
+.cta-content {
+  max-width: 40rem;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.cta-content h2 {
+  font-size: 2.5rem;
+  font-weight: 700;
+  line-height: 1.2;
+  margin-bottom: 1rem;
+}
+
+.cta-subtitle {
+  font-size: 1.25rem;
+  opacity: 0.9;
+  margin-bottom: 2rem;
+}
+
+/* Responsive */
+@media (min-width: 768px) {
+  .about-content.with-image {
+    grid-template-columns: 1fr 1fr;
+  }
+  
+  .about-content.with-image .about-text {
+    text-align: left;
+  }
+}


### PR DESCRIPTION
## Summary
- implement `AboutLight` component
- implement `CTAFinalLight` component
- append related styles
- wire new components into landing page renderer

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_685dc7138438832988c9e801e0d4d784