### PR TITLE
feat: add funnel utilities and workflow

### DIFF
--- a/.github/workflows/create-lp-pr-v2.yml
+++ b/.github/workflows/create-lp-pr-v2.yml
@@ -1,0 +1,210 @@
+name: Create Multi-Funnel LP Pull Request
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  create-funnel-lp-pr:
+    if: startsWith(github.event.issue.title, '[DEPLOY]')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Extract client data and funnel stages
+        id: extract
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const issueTitle = context.payload.issue.title;
+            const issueBody = context.payload.issue.body;
+
+            // Extrai nome do cliente: [DEPLOY] cliente - Nome
+            const match = issueTitle.match(/\[DEPLOY\]\s*(\w+)/);
+            const clientId = match ? match[1].toLowerCase() : 'default';
+
+            // Valida e extrai JSON
+            let jsonData;
+            try {
+              jsonData = JSON.parse(issueBody);
+            } catch (e) {
+              throw new Error('JSON inválido no corpo da Issue');
+            }
+
+            // Extrai etapas do funil
+            const etapas = jsonData.etapas || ['bofu']; // Default só vendas
+            const validEtapas = etapas.filter(e => ['tofu', 'mofu', 'bofu'].includes(e));
+
+            if (validEtapas.length === 0) {
+              throw new Error('Nenhuma etapa válida especificada');
+            }
+
+            // Calcula preços
+            const precos = { tofu: 297, mofu: 397, bofu: 497 };
+            const total = validEtapas.reduce((sum, etapa) => sum + precos[etapa], 0);
+            const pacote = 797;
+            const economia = total - pacote;
+
+            // Salva outputs
+            core.setOutput('client_id', clientId);
+            core.setOutput('etapas', JSON.stringify(validEtapas));
+            core.setOutput('json_data', JSON.stringify(jsonData));
+            core.setOutput('total_individual', total);
+            core.setOutput('total_pacote', pacote);
+            core.setOutput('economia', economia);
+            core.setOutput('branch_name', `lp-${clientId}-${Date.now()}`);
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Create Funnel LPs
+        run: |
+          CLIENT_ID="${{ steps.extract.outputs.client_id }}"
+          ETAPAS='${{ steps.extract.outputs.etapas }}'
+          JSON_DATA='${{ steps.extract.outputs.json_data }}'
+
+          echo "Criando LPs para cliente: $CLIENT_ID"
+          echo "Etapas: $ETAPAS"
+
+          # Parse das etapas
+          ETAPAS_ARRAY=$(echo $ETAPAS | jq -r '.[]')
+
+          for ETAPA in $ETAPAS_ARRAY; do
+            echo "Criando LP para etapa: $ETAPA"
+
+            # Cria estrutura de pastas
+            LP_DIR="lps/${CLIENT_ID}-${ETAPA}"
+            mkdir -p $LP_DIR
+
+            # Processa template da etapa
+            node -e "
+              const fs = require('fs');
+              const path = require('path');
+
+              // Carrega template da etapa
+              const templatePath = path.join('templates', 'bases', '$ETAPA.json');
+              const template = JSON.parse(fs.readFileSync(templatePath, 'utf8'));
+
+              // Carrega dados do cliente
+              const clientData = $JSON_DATA;
+
+              // Processa template (substituição simples por enquanto)
+              let templateStr = JSON.stringify(template);
+              Object.entries(clientData).forEach(([key, value]) => {
+                const regex = new RegExp('{{' + key + '}}', 'g');
+                templateStr = templateStr.replace(regex, String(value));
+              });
+
+              // Remove variáveis não substituídas
+              templateStr = templateStr.replace(/{{[^}]+}}/g, 'PENDENTE');
+
+              // Salva LP processada
+              fs.writeFileSync(path.join('$LP_DIR', 'lp.json'), templateStr);
+            "
+
+            # Cria README para a LP
+            cat > $LP_DIR/README.md << EOF2
+          # Landing Page - ${CLIENT_ID}-${ETAPA}
+
+          Criada em: $(date)
+          Via Issue: #${{ github.event.issue.number }}
+          Etapa do Funil: ${ETAPA^^}
+          Cliente: $CLIENT_ID
+
+          ## Arquivos
+          - \`lp.json\`: Configuração da landing page
+
+          ## URLs
+          - Produção: https://seusite.com/${CLIENT_ID}-${ETAPA}
+          - Desenvolvimento: http://localhost:3000/${CLIENT_ID}-${ETAPA}
+
+          ## Preço
+EOF2
+
+            case $ETAPA in
+              "tofu") echo "- R$ 297 (Captura de Leads)" >> $LP_DIR/README.md ;;
+              "mofu") echo "- R$ 397 (Nutrição)" >> $LP_DIR/README.md ;;
+              "bofu") echo "- R$ 497 (Vendas)" >> $LP_DIR/README.md ;;
+            esac
+
+            echo "" >> $LP_DIR/README.md
+            echo "## Deploy" >> $LP_DIR/README.md
+            echo "Esta LP será automaticamente deployada pela Vercel." >> $LP_DIR/README.md
+
+          done
+
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "feat: Add Funnel LPs for ${{ steps.extract.outputs.client_id }}"
+          title: "🚀 Funil Completo: ${{ steps.extract.outputs.client_id }}"
+          body: |
+            ## Novo Funil de Landing Pages criado via Issue #${{ github.event.issue.number }}
+
+            ### Cliente: `${{ steps.extract.outputs.client_id }}`
+            ### Etapas Criadas: ${{ steps.extract.outputs.etapas }}
+
+            ### 💰 Investimento:
+            - **Individual**: R$ ${{ steps.extract.outputs.total_individual }}
+            - **Pacote Completo**: R$ ${{ steps.extract.outputs.total_pacote }}
+            - **Economia**: R$ ${{ steps.extract.outputs.economia }}
+
+            ### 📁 Arquivos criados:
+            $(echo '${{ steps.extract.outputs.etapas }}' | jq -r '.[] | "- ✅ `/lps/${{ steps.extract.outputs.client_id }}-" + . + "/`"')
+
+            ### 🌐 URLs que serão ativadas:
+            $(echo '${{ steps.extract.outputs.etapas }}' | jq -r '.[] | "- 🔗 `/${{ steps.extract.outputs.client_id }}-" + . + "`"')
+
+            ### Próximos passos:
+            1. Revise os arquivos criados
+            2. Aprove este PR para fazer deploy
+            3. A Issue será fechada automaticamente
+            4. Cliente receberá acesso às URLs
+
+            ---
+            *Criado automaticamente pelo LP Factory Bot* 🤖
+          branch: ${{ steps.extract.outputs.branch_name }}
+          delete-branch: true
+          labels: |
+            landing-page
+            funnel
+            automated
+          assignees: AlcinoAfonso
+
+      - name: Comment on Issue
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const prNumber = "${{ steps.cpr.outputs.pull-request-number }}";
+            const prUrl = "${{ steps.cpr.outputs.pull-request-url }}";
+            const etapas = JSON.parse('${{ steps.extract.outputs.etapas }}');
+            const cliente = '${{ steps.extract.outputs.client_id }}';
+
+            let urlsList = etapas.map(etapa => `- 🔗 **${etapa.toUpperCase()}**: \`/${cliente}-${etapa}\``).join('\n');
+
+            if (prNumber && prUrl) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: `✅ **Funil de Landing Pages criado com sucesso!**\n\n🔗 **PR #${prNumber}**: ${prUrl}\n\n📊 **Resumo do Pedido:**\n- Cliente: \`${cliente}\`\n- Etapas: ${etapas.join(', ').toUpperCase()}\n- Total Individual: R$ ${{ steps.extract.outputs.total_individual }}\n- Pacote Completo: R$ ${{ steps.extract.outputs.total_pacote }}\n- Economia: R$ ${{ steps.extract.outputs.economia }}\n\n🌐 **URLs que serão ativadas:**\n${urlsList}\n\nRevise e aprove o PR para fazer deploy das landing pages.`
+              });
+            }
+
+            // Fecha a Issue
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              state: 'closed',
+              labels: ['processado', 'funil-completo']
+            });

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -11,6 +11,7 @@ interface PageProps {
   };
 }
 
+// Parse do slug para extrair cliente e etapa
 function parseSlug(slug: string): { cliente: string; etapa: string } | null {
   const parts = slug.split('-');
   if (parts.length < 2) return null;
@@ -25,6 +26,7 @@ function parseSlug(slug: string): { cliente: string; etapa: string } | null {
   return { cliente, etapa };
 }
 
+// Função para buscar dados da LP
 async function getLandingPageData(slug: string): Promise<LandingPageData | null> {
   try {
     const parsed = parseSlug(slug);
@@ -56,14 +58,18 @@ async function getLandingPageData(slug: string): Promise<LandingPageData | null>
   }
 }
 
+// Mock da função que buscaria dados do cliente
 async function getClientData(cliente: string) {
+  // Em produção, isso viria de um banco de dados ou API
   return {
     empresa: cliente.charAt(0).toUpperCase() + cliente.slice(1),
     problema: 'seu problema principal',
     tagline: 'Soluções inteligentes',
+    // ... outros dados do cliente
   };
 }
 
+// Gera metadata dinâmica
 export async function generateMetadata({ params }: PageProps) {
   const data = await getLandingPageData(params.slug);
 
@@ -83,6 +89,7 @@ export async function generateMetadata({ params }: PageProps) {
   };
 }
 
+// Gera rotas estáticas para build
 export async function generateStaticParams() {
   try {
     const lpsDir = path.join(process.cwd(), 'lps');

--- a/src/lib/funnel-system.ts
+++ b/src/lib/funnel-system.ts
@@ -1,0 +1,69 @@
+export interface FunnelPricing {
+  tofu: number;
+  mofu: number;
+  bofu: number;
+  package: number; // Desconto no pacote completo
+}
+
+export interface ClientOrder {
+  cliente: string;
+  etapas: ('tofu' | 'mofu' | 'bofu')[];
+  total: number;
+  discount?: number;
+}
+
+export const funnelPricing: FunnelPricing = {
+  tofu: 297,
+  mofu: 397,
+  bofu: 497,
+  package: 797, // Preço do pacote completo (economia de R$ 294)
+};
+
+export function calculateOrder(etapas: ('tofu' | 'mofu' | 'bofu')[]): {
+  individual: number;
+  package: number;
+  savings: number;
+  recommendPackage: boolean;
+} {
+  const individual = etapas.reduce((sum, etapa) => sum + funnelPricing[etapa], 0);
+  const packagePrice = funnelPricing.package;
+  const savings = individual - packagePrice;
+  const recommendPackage = etapas.length >= 2 && savings > 0;
+
+  return {
+    individual,
+    package: packagePrice,
+    savings,
+    recommendPackage,
+  };
+}
+
+export function getEtapaDescription(etapa: 'tofu' | 'mofu' | 'bofu'): {
+  name: string;
+  description: string;
+  price: number;
+  goal: string;
+} {
+  const descriptions = {
+    tofu: {
+      name: 'TOFU - Captura de Leads',
+      description: 'Landing page para capturar leads com materiais educativos',
+      price: funnelPricing.tofu,
+      goal: 'Gerar consciência e capturar contatos',
+    },
+    mofu: {
+      name: 'MOFU - Nutrição',
+      description: 'Landing page para nutrir leads com webinars e conteúdo avançado',
+      price: funnelPricing.mofu,
+      goal: 'Educar e qualificar leads',
+    },
+    bofu: {
+      name: 'BOFU - Vendas',
+      description: 'Landing page de vendas com foco em conversão',
+      price: funnelPricing.bofu,
+      goal: 'Converter leads em clientes',
+    },
+  } as const;
+
+  return descriptions[etapa];
+}

--- a/src/lib/template-processor.ts
+++ b/src/lib/template-processor.ts
@@ -14,12 +14,93 @@ export async function getFunnelTemplate(etapa: 'tofu' | 'mofu' | 'bofu'): Promis
 }
 
 export function processTemplate(template: LandingPageData, data: Record<string, any>): LandingPageData {
+  // Converte o template em string para fazer replace
   let templateStr = JSON.stringify(template);
 
+  // Substitui todas as variáveis {{variavel}} pelos dados
   Object.entries(data).forEach(([key, value]) => {
     const regex = new RegExp(`{{${key}}}`, 'g');
     templateStr = templateStr.replace(regex, String(value));
   });
 
+  // Remove variáveis não substituídas (opcional)
+  templateStr = templateStr.replace(/{{[^}]+}}/g, '');
+
   return JSON.parse(templateStr) as LandingPageData;
+}
+
+// Função para criar LP automaticamente
+export async function createClientLP(
+  cliente: string,
+  etapas: ('tofu' | 'mofu' | 'bofu')[],
+  clientData: Record<string, any>
+) {
+  const results = [] as Array<{ slug: string; etapa: string; success: boolean; url?: string; error?: string }>;
+
+  for (const etapa of etapas) {
+    try {
+      // Carrega template da etapa
+      const template = await getFunnelTemplate(etapa);
+      if (!template) continue;
+
+      // Processa template com dados do cliente
+      const processedLP = processTemplate(template, clientData);
+
+      // Cria diretório
+      const lpDir = path.join(process.cwd(), 'lps', `${cliente}-${etapa}`);
+      await fs.mkdir(lpDir, { recursive: true });
+
+      // Salva LP processada
+      const lpPath = path.join(lpDir, 'lp.json');
+      await fs.writeFile(lpPath, JSON.stringify(processedLP, null, 2));
+
+      // Cria README
+      const readmePath = path.join(lpDir, 'README.md');
+      const readmeContent = `# Landing Page - ${cliente}-${etapa}
+
+Criada em: ${new Date().toISOString()}
+Etapa do Funil: ${etapa.toUpperCase()}
+Cliente: ${cliente}
+
+## Arquivos
+- \`lp.json\`: Configuração da landing page
+
+## URLs
+- Produção: https://seusite.com/${cliente}-${etapa}
+- Desenvolvimento: http://localhost:3000/${cliente}-${etapa}
+
+## Preço
+- ${getEtapaPrice(etapa)}
+
+## Deploy
+Esta LP será automaticamente deployada pela Vercel.
+`;
+      await fs.writeFile(readmePath, readmeContent);
+
+      results.push({
+        slug: `${cliente}-${etapa}`,
+        etapa,
+        success: true,
+        url: `/${cliente}-${etapa}`,
+      });
+    } catch (error: any) {
+      results.push({
+        slug: `${cliente}-${etapa}`,
+        etapa,
+        success: false,
+        error: error.message,
+      });
+    }
+  }
+
+  return results;
+}
+
+function getEtapaPrice(etapa: string): string {
+  const prices: Record<string, string> = {
+    tofu: 'R$ 297',
+    mofu: 'R$ 397',
+    bofu: 'R$ 497',
+  };
+  return prices[etapa] || 'R$ 0';
 }


### PR DESCRIPTION
## Summary
- add slug page comments and client data helper
- extend template processor to create multi-stage LPs
- add funnel-system helpers for pricing
- add workflow for funnel PR automation

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685f230c6d948329afb27cdfe237d212