### PR TITLE
Add v2 landing page routes

### DIFF
--- a/src/app/[slug]/page-v2.tsx
+++ b/src/app/[slug]/page-v2.tsx
@@ -1,0 +1,215 @@
+import { notFound } from 'next/navigation';
+import LandingPage from '@/components/LandingPage';
+import { LandingPageData } from '@/types/lp-config';
+import fs from 'fs/promises';
+import path from 'path';
+
+interface PageProps {
+  params: {
+    slug: string;
+  };
+}
+
+// Função para buscar dados da LP (nova estrutura)
+async function getLandingPageData(slug: string): Promise<LandingPageData | null> {
+  try {
+    // Tenta carregar LP na nova estrutura: /lps/cliente-nome-lp/
+    const filePath = path.join(process.cwd(), 'lps', slug, 'lp.json');
+    const fileExists = await fs
+      .access(filePath)
+      .then(() => true)
+      .catch(() => false);
+
+    if (fileExists) {
+      const fileContent = await fs.readFile(filePath, 'utf8');
+      const lpData = JSON.parse(fileContent);
+
+      // Converte nova estrutura para formato compatível se necessário
+      return convertToLegacyFormat(lpData);
+    }
+
+    console.error(`LP não encontrada: ${slug}`);
+    return null;
+  } catch (error) {
+    console.error(`Erro ao carregar LP para ${slug}:`, error);
+    return null;
+  }
+}
+
+// Converte nova estrutura para formato compatível com componentes existentes
+function convertToLegacyFormat(newFormat: any): LandingPageData {
+  return {
+    metadata: newFormat.metadata,
+    sections: newFormat.sections.map((section: any) => {
+      // Mapeia campos específicos baseado no tipo da seção
+      switch (section.type) {
+        case 'header':
+          return {
+            ...section,
+            logo: section.logo_url ?
+              { type: 'image', src: section.logo_url, alt: 'Logo' } :
+              { type: 'text', text: 'Logo', subtitle: '' },
+            navigation: section.navegacao || [],
+            phone: section.telefone ? {
+              display: section.telefone.exibicao,
+              link: section.telefone.link
+            } : undefined
+          };
+
+        case 'hero':
+          return {
+            ...section,
+            title: section.h1 || section.title,
+            description: section.paragrafo || section.description,
+            primaryButton: section.botao_whatsapp ? {
+              text: section.botao_whatsapp.rotulo,
+              href: `https://wa.me/${section.botao_whatsapp.numero}?text=${encodeURIComponent(section.botao_whatsapp.mensagem)}`,
+              variant: 'primary'
+            } : section.primaryButton,
+            image: section.imagem_url ?
+              { src: section.imagem_url, alt: 'Hero Image' } :
+              section.image
+          };
+
+        case 'services':
+          return {
+            ...section,
+            title: section.h2 || section.title,
+            image: section.imagem_url ?
+              { src: section.imagem_url, alt: 'Services Image' } :
+              section.image,
+            button: section.botao_whatsapp ? {
+              text: section.botao_whatsapp.rotulo,
+              href: `https://wa.me/${section.botao_whatsapp.numero}?text=${encodeURIComponent(section.botao_whatsapp.mensagem)}`,
+              variant: 'primary'
+            } : section.button
+          };
+
+        case 'testimonials':
+          return {
+            ...section,
+            title: section.h2 || section.title,
+            videos: section.youtube_links ?
+              section.youtube_links.map((link: string, index: number) => {
+                const videoId = link.match(/v=([^&]+)/)?.[1];
+                return {
+                  embedUrl: `https://www.youtube.com/embed/${videoId}`,
+                  title: `Depoimento ${index + 1}`
+                };
+              }) :
+              section.videos
+          };
+
+        case 'steps':
+          return {
+            ...section,
+            title: section.h2 || section.title,
+            button: section.botao_whatsapp ? {
+              text: section.botao_whatsapp.rotulo,
+              href: `https://wa.me/${section.botao_whatsapp.numero}?text=${encodeURIComponent(section.botao_whatsapp.mensagem)}`,
+              variant: 'primary'
+            } : section.button
+          };
+
+        case 'about':
+          return {
+            ...section,
+            title: section.h2 || section.title,
+            description: section.texto || section.description,
+            image: section.imagem_url ?
+              { src: section.imagem_url, alt: 'About Image' } :
+              section.image
+          };
+
+        case 'ctaFinal':
+          return {
+            ...section,
+            title: section.h2 || section.title,
+            subtitle: section.h3 || section.subtitle,
+            button: section.botao_whatsapp ? {
+              text: section.botao_whatsapp.rotulo,
+              href: `https://wa.me/${section.botao_whatsapp.numero}?text=${encodeURIComponent(section.botao_whatsapp.mensagem)}`,
+              variant: 'primary'
+            } : section.button
+          };
+
+        case 'footer':
+          return {
+            ...section,
+            instagram: {
+              url: section.instagram_url,
+              text: '@empresa'
+            },
+            legalLink: section.termo_uso ? {
+              text: section.termo_uso.texto,
+              href: section.termo_uso.url
+            } : section.legalLink
+          };
+
+        default:
+          return section;
+      }
+    })
+  };
+}
+
+// Gera metadata dinâmica
+export async function generateMetadata({ params }: PageProps) {
+  const data = await getLandingPageData(params.slug);
+
+  if (!data) {
+    return {
+      title: 'Página não encontrada',
+      description: 'A página que você procura não existe.',
+    };
+  }
+
+  return {
+    title: data.metadata.title,
+    description: data.metadata.description,
+    icons: {
+      icon: data.metadata.favicon || '/favicon.ico',
+    },
+  };
+}
+
+// Gera rotas estáticas para build
+export async function generateStaticParams() {
+  try {
+    const lpsDir = path.join(process.cwd(), 'lps');
+    const entries = await fs.readdir(lpsDir);
+
+    const validSlugs = [] as Array<{ slug: string }>;
+    for (const entry of entries) {
+      const entryPath = path.join(lpsDir, entry);
+      const stats = await fs.stat(entryPath);
+
+      if (stats.isDirectory()) {
+        const lpJsonPath = path.join(entryPath, 'lp.json');
+        const hasLpJson = await fs
+          .access(lpJsonPath)
+          .then(() => true)
+          .catch(() => false);
+
+        if (hasLpJson) {
+          validSlugs.push({ slug: entry });
+        }
+      }
+    }
+
+    return validSlugs;
+  } catch (error) {
+    console.error('Erro ao gerar parâmetros estáticos:', error);
+    return [];
+  }
+}
+
+export default async function SlugLandingPage({ params }: PageProps) {
+  const data = await getLandingPageData(params.slug);
+
+  if (!data) {
+    notFound();
+  }
+
+  return <LandingPage data={data} />;
+}

--- a/src/app/lps/page-v2.tsx
+++ b/src/app/lps/page-v2.tsx
@@ -1,0 +1,141 @@
+import Link from 'next/link';
+import fs from 'fs/promises';
+import path from 'path';
+import { LandingPageData } from '@/types/lp-config';
+
+interface LPInfo {
+  slug: string;
+  cliente: string;
+  lpNome: string;
+  title: string;
+  description: string;
+  url: string;
+  dataCriacao?: string;
+  secoesCount: number;
+}
+
+async function getAllLandingPagesV2(): Promise<LPInfo[]> {
+  try {
+    const lpsDir = path.join(process.cwd(), 'lps');
+    const clients = await fs.readdir(lpsDir);
+
+    const landingPages: LPInfo[] = [];
+
+    for (const clientDir of clients) {
+      const clientPath = path.join(lpsDir, clientDir);
+      const stats = await fs.stat(clientPath);
+
+      if (stats.isDirectory()) {
+        const lpJsonPath = path.join(clientPath, 'lp.json');
+
+        try {
+          const fileContent = await fs.readFile(lpJsonPath, 'utf8');
+          const data = JSON.parse(fileContent) as any;
+
+          // Extrai informações
+          const slug = clientDir;
+          const [cliente, ...lpNomeParts] = slug.split('-');
+          const lpNome = lpNomeParts.join('-') || 'principal';
+
+          landingPages.push({
+            slug,
+            cliente,
+            lpNome,
+            title: data.metadata?.title || `${cliente} - ${lpNome}`,
+            description: data.metadata?.description || 'Landing Page',
+            url: `/${slug}`,
+            dataCriacao: data.creation_info?.data_criacao,
+            secoesCount: data.sections?.length || 0
+          });
+        } catch (error) {
+          console.error(`Erro ao ler LP de ${clientDir}:`, error);
+        }
+      }
+    }
+
+    return landingPages.sort((a, b) => {
+      // Ordena por data de criação (mais recente primeiro)
+      if (a.dataCriacao && b.dataCriacao) {
+        return new Date(b.dataCriacao).getTime() - new Date(a.dataCriacao).getTime();
+      }
+      return a.slug.localeCompare(b.slug);
+    });
+  } catch (error) {
+    console.error('Erro ao listar LPs:', error);
+    return [];
+  }
+}
+
+export const metadata = {
+  title: 'Todas as Landing Pages - LP Factory V3',
+  description: 'Lista de todas as landing pages criadas pela LP Factory',
+};
+
+export default async function LandingPagesListPageV2() {
+  const landingPages = await getAllLandingPagesV2();
+
+  // Agrupa por cliente
+  const groupedByCliente = landingPages.reduce((acc, lp) => {
+    if (!acc[lp.cliente]) {
+      acc[lp.cliente] = [];
+    }
+    acc[lp.cliente].push(lp);
+    return acc;
+  }, {} as Record<string, LPInfo[]>);
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-12">
+      <div className="container-lp">
+        <div className="text-center mb-12">
+          <h1 className="text-4xl font-bold mb-4">
+            Landing Pages Factory V3
+          </h1>
+          <p className="text-gray-600">
+            {landingPages.length} landing pages ativas • Sistema de briefs estruturados
+          </p>
+        </div>
+
+        {landingPages.length === 0 ? (
+          <div className="text-center">
+            <p className="text-gray-600 mb-8">
+              Nenhuma landing page encontrada.
+            </p>
+            <div className="bg-white p-6 rounded-lg shadow-md max-w-md mx-auto">
+              <h3 className="font-semibold mb-2">Como criar uma LP:</h3>
+              <ol className="text-left text-sm text-gray-600 space-y-1">
+                <li>1. Abra uma Issue no GitHub</li>
+                <li>2. Título: <code>[LP] cliente - nome-da-lp</code></li>
+                <li>3. Corpo: Brief estruturado</li>
+                <li>4. Aguarde o processamento automático</li>
+              </ol>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-8">
+            {Object.entries(groupedByCliente).map(([cliente, lps]) => (
+              <div key={cliente} className="bg-white p-6 rounded-lg shadow-md">
+                <h2 className="text-xl font-semibold mb-4">{cliente}</h2>
+                <ul className="space-y-2">
+                  {lps.map((lp) => (
+                    <li key={lp.slug}>
+                      <Link href={lp.url} className="text-blue-600 hover:text-blue-800">
+                        {lp.lpNome}
+                      </Link>
+                      <span className="ml-2 text-gray-500">({lp.secoesCount} seções)</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div className="mt-12 text-center">
+          <Link href="/" className="text-gray-600 hover:text-gray-800 underline">
+            ← Voltar para a página inicial
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add dynamic `[slug]/page-v2` route to support new LP structure
- add `lps/page-v2` listing page for V3 landing pages

## Testing
- `npm run type-check` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_686168d8af6883298ac3af9db38eae6e