### PR TITLE
Implement LP Factory V3 basics

### DIFF
--- a/.github/workflows/create-lp-v3.yml
+++ b/.github/workflows/create-lp-v3.yml
@@ -1,0 +1,16 @@
+name: Create LP V3
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Parse brief
+        run: |
+          echo "Parsing brief (placeholder)"
+      - name: Create PR
+        run: |
+          echo "PR would be created here"

--- a/lps/agencia-portfolio/README.md
+++ b/lps/agencia-portfolio/README.md
@@ -1,0 +1,2 @@
+# Agência Portfolio
+LP exemplo do sistema V3.

--- a/lps/agencia-portfolio/lp.json
+++ b/lps/agencia-portfolio/lp.json
@@ -1,0 +1,8 @@
+{
+  "metadata": {
+    "title": "Agência Portfolio",
+    "description": "Modelo de portfolio",
+    "favicon": "/favicon.ico"
+  },
+  "sections": []
+}

--- a/lps/empresa-captura-leads/README.md
+++ b/lps/empresa-captura-leads/README.md
@@ -1,0 +1,2 @@
+# Empresa Captura Leads
+LP exemplo do sistema V3.

--- a/lps/empresa-captura-leads/lp.json
+++ b/lps/empresa-captura-leads/lp.json
@@ -1,0 +1,8 @@
+{
+  "metadata": {
+    "title": "Empresa - Captura de Leads",
+    "description": "Landing page exemplo",
+    "favicon": "/favicon.ico"
+  },
+  "sections": []
+}

--- a/lps/quantec-terapia-quantica/README.md
+++ b/lps/quantec-terapia-quantica/README.md
@@ -1,0 +1,2 @@
+# Quantec Portal - Terapia Quântica
+Exemplo de landing page gerada pelo sistema V3.

--- a/lps/quantec-terapia-quantica/lp.json
+++ b/lps/quantec-terapia-quantica/lp.json
@@ -1,0 +1,81 @@
+{
+  "metadata": {
+    "title": "Quantec Portal - Terapia Quântica",
+    "description": "Capturar leads interessados em terapia",
+    "favicon": "/favicon.ico"
+  },
+  "creation_info": {
+    "data_criacao": "2025-07-01T00:00:00.000Z"
+  },
+  "sections": [
+    {
+      "id": "header",
+      "type": "header",
+      "logo_url": "https://quantecportal.com/logo.svg",
+      "menu": [
+        { "nome": "sobre", "link": "#about" },
+        { "nome": "depoimentos", "link": "#testimonials" }
+      ],
+      "telefone": {
+        "exibicao": "(21) 97965-8483",
+        "link": "21979658483"
+      }
+    },
+    {
+      "id": "hero",
+      "type": "hero",
+      "h1": "Medicina Quântica Segura Com Tecnologia de Ponta",
+      "p": "Terapia Quântica não invasiva, reconhecida na Europa.",
+      "botao_whatsapp": {
+        "rotulo": "Entenda os Benefícios",
+        "numero": "5521979658483",
+        "mensagem": "Gostaria de saber mais sobre a terapia"
+      },
+      "imagem_url": "https://quantecportal.com/foto-angelo.webp"
+    },
+    {
+      "id": "benefits",
+      "type": "benefits",
+      "ai": true
+    },
+    {
+      "id": "services",
+      "type": "services",
+      "h2": "Terapia Quântica: Como Funciona",
+      "items": [
+        { "icon": "🧠", "text": "A terapia busca identificar padrões sutis..." },
+        { "icon": "⚖️", "text": "Esses desequilíbrios podem estar por trás..." }
+      ],
+      "imagem_url": "https://quantecportal.com/image.webp",
+      "botao_whatsapp": {
+        "rotulo": "Entenda os Benefícios",
+        "numero": "5521979658483",
+        "mensagem": "Gostaria de saber mais"
+      }
+    },
+    {
+      "id": "testimonials",
+      "type": "testimonials",
+      "h2": "Depoimentos dos Clientes",
+      "youtube_links": [
+        "https://www.youtube.com/watch?v=8AIcDOsxS7Q",
+        "https://www.youtube.com/watch?v=Mwr6JtFcwtY"
+      ]
+    },
+    {
+      "id": "faq",
+      "type": "faq",
+      "ai": true
+    },
+    {
+      "id": "footer",
+      "type": "footer",
+      "instagram_url": "https://instagram.com/quantecportal",
+      "copyright": "Quantec Portal © 2025",
+      "termo_uso": {
+        "texto": "Termos",
+        "url": "https://quantecportal.com/termos"
+      }
+    }
+  ]
+}

--- a/src/lib/brief-processor.ts
+++ b/src/lib/brief-processor.ts
@@ -1,0 +1,79 @@
+import { LandingPageV2 } from '@/types/lp-config-v2';
+
+const sections = [
+  'header',
+  'hero',
+  'benefits',
+  'services',
+  'testimonials',
+  'steps',
+  'about',
+  'faq',
+  'ctaFinal',
+  'footer',
+];
+
+export function parseBrief(content: string): LandingPageV2 {
+  const lines = content
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l);
+
+  const lp: LandingPageV2 = {
+    metadata: { title: '', description: '' },
+    sections: [],
+    creation_info: { data_criacao: new Date().toISOString() },
+  };
+
+  let current: string | null = null;
+  let data: Record<string, any> = {};
+
+  const pushSection = () => {
+    if (!current) return;
+    lp.sections.push({ id: current!, type: current!, ...data });
+    current = null;
+    data = {};
+  };
+
+  for (const line of lines) {
+    if (sections.includes(line)) {
+      pushSection();
+      current = line === 'ctafinal' ? 'ctaFinal' : line;
+      continue;
+    }
+
+    if (line === 'IA' && current) {
+      data.ai = true;
+      continue;
+    }
+
+    if (!current) {
+      const [key, ...rest] = line.split(':');
+      const value = rest.join(':').trim();
+      switch (key.toLowerCase()) {
+        case 'empresa':
+          lp.metadata.title = value;
+          break;
+        case 'objetivo da lp':
+          lp.metadata.description = value;
+          break;
+        default:
+          break;
+      }
+      continue;
+    }
+
+    const [key, ...rest] = line.split(':');
+    if (rest.length > 0) {
+      data[key.trim()] = rest.join(':').trim();
+    } else if (/^[\p{Emoji_Presentation}\p{Emoji}]/u.test(line)) {
+      const icon = line.charAt(0);
+      const text = line.substring(1).trim();
+      data.items = data.items || [];
+      data.items.push({ icon, text });
+    }
+  }
+
+  pushSection();
+  return lp;
+}

--- a/src/types/lp-config-v2.ts
+++ b/src/types/lp-config-v2.ts
@@ -1,0 +1,21 @@
+export interface SectionBase {
+  type: string;
+  id: string;
+  [key: string]: any;
+}
+
+export interface MetadataV2 {
+  title: string;
+  description: string;
+  favicon?: string;
+}
+
+export interface CreationInfo {
+  data_criacao: string;
+}
+
+export interface LandingPageV2 {
+  metadata: MetadataV2;
+  sections: SectionBase[];
+  creation_info?: CreationInfo;
+}


### PR DESCRIPTION
## Summary
- add initial LP Factory V3 types and brief processor
- include example landing pages using new format
- add skeleton GitHub workflow for automatic LP creation

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run type-check` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6862c1d70b1083298c2eba81991f58e7